### PR TITLE
Fix ajax parameters when ? was used on based url.

### DIFF
--- a/src/resources/assets/buttons.server-side.js
+++ b/src/resources/assets/buttons.server-side.js
@@ -5,7 +5,11 @@
         var url = dt.ajax.url() || '';
         var params = dt.ajax.params();
         params.action = action;
-
+        
+        if (url.indexOf("?")) {
+            return url + '&' + $.param(params);
+        }
+        
         return url + '?' + $.param(params);
     };
 


### PR DESCRIPTION
Hi, I added support for rendering 2 tables in a single page.

The idea was pretty simple. 

I had 2 tables in `/users`, `ActiveUsersDataTable` and `InactiveUsersDataTable`.

- I added and `id` field to use in html part of the datatable so that the ids won't conflict.
- I added `?tableId=TableID` to each request so that we can define which table we're querying with the ajax request to the backend.
- I edited the `server-side.buttons.js` to allow urls with a query parameter.
