### PR TITLE
Adding model-namespace, columns and action options to Generator

### DIFF
--- a/src/Generators/DataTablesMakeCommand.php
+++ b/src/Generators/DataTablesMakeCommand.php
@@ -208,7 +208,7 @@ class DataTablesMakeCommand extends GeneratorCommand
         return [
             ['model', null, InputOption::VALUE_NONE, 'Use the provided name as the model.', null],
             ['action', null, InputOption::VALUE_OPTIONAL, 'Force the use of singular in filename.', null],
-            ['columns', null, InputOption::VALUE_IS_ARRAY, 'Use the provided columns.', null],
+            ['columns', null, InputOption::VALUE_OPTIONAL, 'Use the provided columns.', null],
         ];
     }
 

--- a/src/Generators/DataTablesMakeCommand.php
+++ b/src/Generators/DataTablesMakeCommand.php
@@ -133,7 +133,7 @@ class DataTablesMakeCommand extends GeneratorCommand
      * Replace the action.
      *
      * @param string $stub
-     * @return string
+     * @return this
      */
     protected function replaceAction(&$stub)
     {
@@ -187,7 +187,7 @@ class DataTablesMakeCommand extends GeneratorCommand
      * Replace the filename.
      *
      * @param string $stub
-     * @return string
+     * @return this
      */
     protected function replaceFilename(&$stub)
     {

--- a/src/Generators/DataTablesMakeCommand.php
+++ b/src/Generators/DataTablesMakeCommand.php
@@ -124,7 +124,7 @@ class DataTablesMakeCommand extends GeneratorCommand
      * @param  int     $indentation
      * @return string
      */
-    protected function parseArray($definition, $delimiter = ',', $indentation = 16)
+    protected function parseArray($definition, $delimiter = ',', $indentation = 12)
     {
         return str_replace($delimiter, "',\n" . str_repeat(' ', $indentation) . "'", $definition);
     }

--- a/src/Generators/DataTablesMakeCommand.php
+++ b/src/Generators/DataTablesMakeCommand.php
@@ -61,7 +61,7 @@ class DataTablesMakeCommand extends GeneratorCommand
      * Replace model name.
      *
      * @param string $stub
-     * @return mixed
+     * @return this
      */
     protected function replaceModel(&$stub)
     {
@@ -187,7 +187,7 @@ class DataTablesMakeCommand extends GeneratorCommand
      * Replace the filename.
      *
      * @param string $stub
-     * @return this
+     * @return string
      */
     protected function replaceFilename(&$stub)
     {

--- a/src/Generators/DataTablesMakeCommand.php
+++ b/src/Generators/DataTablesMakeCommand.php
@@ -178,8 +178,8 @@ class DataTablesMakeCommand extends GeneratorCommand
     protected function getStub()
     {
         $config = $this->laravel['config'];
-        return $config->get('datatables.custom_template')
-            ? $config->get('datatables.custom_path') . '/datatables.stub'
+        return $config->get('datatables-buttons.stub')
+            ? base_path() . $config->get('datatables-buttons.stub') . '/datatables.stub'
             : __DIR__ . '/stubs/datatables.stub';
     }
 
@@ -207,7 +207,7 @@ class DataTablesMakeCommand extends GeneratorCommand
     {
         return [
             ['model', null, InputOption::VALUE_NONE, 'Use the provided name as the model.', null],
-            ['action', null, InputOption::VALUE_OPTIONAL, 'Force the use of singular in filename.', null],
+            ['action', null, InputOption::VALUE_OPTIONAL, 'Path to action column template.', null],
             ['columns', null, InputOption::VALUE_OPTIONAL, 'Use the provided columns.', null],
         ];
     }

--- a/src/Generators/stubs/datatables.stub
+++ b/src/Generators/stubs/datatables.stub
@@ -16,7 +16,7 @@ class DummyClass extends DataTable
     {
         return $this->datatables
             ->eloquent($this->query())
-            ->addColumn('action', 'path.to.action.view');
+            ->addColumn('action', 'DummyAction');
     }
 
     /**
@@ -26,7 +26,7 @@ class DummyClass extends DataTable
      */
     public function query()
     {
-        $query = ModelName::query();
+        $query = ModelName::select($this->getColumns);
 
         return $this->applyScopes($query);
     }
@@ -46,19 +46,16 @@ class DummyClass extends DataTable
     }
 
     /**
-     * Get columns.
-     *
-     * @return array
-     */
-    protected function getColumns()
-    {
-        return [
-            'id',
-            // add your columns
-            'created_at',
-            'updated_at',
-        ];
-    }
+         * Get columns.
+         *
+         * @return array
+         */
+        protected function getColumns()
+        {
+            return [
+                'DummyColumns'
+            ];
+        }
 
     /**
      * Get filename for export.

--- a/src/Generators/stubs/datatables.stub
+++ b/src/Generators/stubs/datatables.stub
@@ -26,7 +26,7 @@ class DummyClass extends DataTable
      */
     public function query()
     {
-        $query = ModelName::select($this->getColumns);
+        $query = ModelName::query()->select($this->getColumns());
 
         return $this->applyScopes($query);
     }

--- a/src/Generators/stubs/datatables.stub
+++ b/src/Generators/stubs/datatables.stub
@@ -46,16 +46,16 @@ class DummyClass extends DataTable
     }
 
     /**
-         * Get columns.
-         *
-         * @return array
-         */
-        protected function getColumns()
-        {
-            return [
-                'DummyColumns'
-            ];
-        }
+     * Get columns.
+     *
+     * @return array
+     */
+    protected function getColumns()
+    {
+        return [
+            'DummyColumns'
+        ];
+    }
 
     /**
      * Get filename for export.

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -27,6 +27,11 @@ return [
     ],
 
     /**
+     * Set Custom stub folder
+     */
+    //'stub' => '/resources/custom_stub',
+
+    /**
      * PDF generator to be used when converting the table to pdf.
      * Available generators: excel, snappy
      * Snappy package: barryvdh/laravel-snappy


### PR DESCRIPTION
Hello,

i've added some options to the DataTable Generator :

- **model-namespace** : 

> allow to overwrite the namespace set in config 
>  implictly enable --model option
> usage : --model-namespace="Models\Client\"

- **columns** :

>  allow to set custom columns
> usage : --columns="id,label,url,address"

- **action** : 

> allow to choose the view to use for column action
> usage : --action="client.action"

i've also introduced a way to use a custom datatables.stub.

if something is wrong, tell me and i will correct it.

thanks