### PR TITLE
Do not require return from before callback closure.

### DIFF
--- a/src/Services/DataTable.php
+++ b/src/Services/DataTable.php
@@ -158,7 +158,7 @@ abstract class DataTable implements DataTableContract, DataTableButtonsContract
         $dataTable = $this->dataTable();
 
         if ($callback = $this->beforeCallback) {
-            $dataTable = $callback($dataTable);
+            $callback($dataTable);
         }
 
         $response = $dataTable->make(true);


### PR DESCRIPTION
Ex:

```php
    public function index(ArticlesDataTable $dataTable)
    {
        return $dataTable->addScope(new OwnedScope))
                         ->before(function (EloquentEngine $engine) {
                             $engine->editColumn('action', 'articles.datatables.action');
                         })
                         ->withHtml(function (Builder $builder) {
                             $builder->removeColumn('articles.is_page', 'articles.hits');
                         })
                         ->render('articles::index');
    }
```