### PR TITLE
Include builder parameters on stub to assist new users.

### DIFF
--- a/src/Generators/stubs/datatables.stub
+++ b/src/Generators/stubs/datatables.stub
@@ -42,7 +42,17 @@ class DummyClass extends DataTable
                     ->columns($this->getColumns())
                     ->ajax('')
                     ->addAction(['width' => '80px'])
-                    ->parameters($this->getBuilderParameters());
+                    ->parameters([
+                        'dom'     => 'Bfrtip',
+                        'order'   => [[0, 'desc']],
+                        'buttons' => [
+                            'create',
+                            'export',
+                            'print',
+                            'reset',
+                            'reload',
+                        ],
+                    ]);
     }
 
     /**
@@ -54,26 +64,6 @@ class DummyClass extends DataTable
     {
         return [
             'DummyColumns'
-        ];
-    }
-
-    /**
-     * Get default builder parameters.
-     *
-     * @return array
-     */
-    protected function getBuilderParameters()
-    {
-        return [
-            'dom'     => 'Bfrtip',
-            'order'   => [[0, 'desc']],
-            'buttons' => [
-                'create',
-                'export',
-                'print',
-                'reset',
-                'reload',
-            ],
         ];
     }
 

--- a/src/Generators/stubs/datatables.stub
+++ b/src/Generators/stubs/datatables.stub
@@ -58,6 +58,26 @@ class DummyClass extends DataTable
     }
 
     /**
+     * Get default builder parameters.
+     *
+     * @return array
+     */
+    protected function getBuilderParameters()
+    {
+        return [
+            'dom'     => 'Bfrtip',
+            'order'   => [[0, 'desc']],
+            'buttons' => [
+                'create',
+                'export',
+                'print',
+                'reset',
+                'reload',
+            ],
+        ];
+    }
+
+    /**
      * Get filename for export.
      *
      * @return string


### PR DESCRIPTION
Include `dom` for buttons by default.
