### PR TITLE
[2.0] Added missing dataTable method

### DIFF
--- a/src/Services/DataTable.php
+++ b/src/Services/DataTable.php
@@ -158,6 +158,16 @@ abstract class DataTable implements DataTableContract, DataTableButtonsContract
     }
 
     /**
+     * Get Datatables instance.
+     *
+     * @return mixed
+     */
+    protected function dataTable()
+    {
+        return $this->datatables->of($this->query());
+    }
+    
+    /**
      * Display ajax response.
      *
      * @return \Illuminate\Http\JsonResponse


### PR DESCRIPTION
Hello, it seems dataTables method used in ajax method when fetching data is missing and results in a fatal error.

<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you read the [Contributing Guidelines](https://github.com/yajra/laravel-datatables-buttons/blob/master/.github/CONTRIBUTING.md)?

If you answered yes, thanks for the PR and we'll get to it ASAP! :)

-->
