### PR TITLE
Adding dataTableVariable property to Services/DataTables

### DIFF
--- a/src/Services/DataTable.php
+++ b/src/Services/DataTable.php
@@ -18,7 +18,14 @@ abstract class DataTable implements DataTableButtons
      * @var string
      */
     protected $printPreview = 'datatables::print';
-
+    
+    /**
+     * Name of the dataTable variable
+     *
+     * @var string
+     */
+    protected $dataTableVariable = 'dataTable';
+    
     /**
      * List of columns to be exported.
      *
@@ -118,7 +125,7 @@ abstract class DataTable implements DataTableButtons
             return app()->call([$this, $action]);
         }
 
-        return view($view, $data, $mergeData)->with('dataTable', $this->getHtmlBuilder());
+        return view($view, $data, $mergeData)->with($this->dataTableVariable, $this->getHtmlBuilder());
     }
 
     /**

--- a/src/Services/DataTable.php
+++ b/src/Services/DataTable.php
@@ -20,7 +20,7 @@ abstract class DataTable implements DataTableButtons
     protected $printPreview = 'datatables::print';
     
     /**
-     * Name of the dataTable variable
+     * Name of the dataTable variable.
      *
      * @var string
      */


### PR DESCRIPTION
Hello,

i'm adding dataTableVariable property to Services/DataTables.
The default value is dataTable like before, but can be overwritten by setting the dataTableVariable property in our custom dataTable class :

```
$dataTableVariable = 'MyDataTable';
```

Thanks.