### PR TITLE
Add export CSV with post as a method.

### DIFF
--- a/src/resources/assets/buttons.server-side.js
+++ b/src/resources/assets/buttons.server-side.js
@@ -1,6 +1,64 @@
 (function ($, DataTable) {
     "use strict";
 
+    var _buildParams = function (dt, action) {
+        var params = dt.ajax.params();
+        params.action = action;
+        params._token = $.fn.dataTable.defaults.csrf_token;
+
+        return params;
+    };
+
+    var _downloadFromUrl = function (url, params) {
+        var postUrl = url + '/export';
+        var xhr = new XMLHttpRequest();
+        xhr.open('POST', postUrl, true);
+        xhr.responseType = 'arraybuffer';
+        xhr.onload = function () {
+            if (this.status === 200) {
+                var filename = "";
+                var disposition = xhr.getResponseHeader('Content-Disposition');
+                if (disposition && disposition.indexOf('attachment') !== -1) {
+                    var filenameRegex = /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/;
+                    var matches = filenameRegex.exec(disposition);
+                    if (matches != null && matches[1]) filename = matches[1].replace(/['"]/g, '');
+                }
+                var type = xhr.getResponseHeader('Content-Type');
+
+                var blob = new Blob([this.response], {type: type});
+                if (typeof window.navigator.msSaveBlob !== 'undefined') {
+                    // IE workaround for "HTML7007: One or more blob URLs were revoked by closing the blob for which they were created. These URLs will no longer resolve as the data backing the URL has been freed."
+                    window.navigator.msSaveBlob(blob, filename);
+                } else {
+                    var URL = window.URL || window.webkitURL;
+                    var downloadUrl = URL.createObjectURL(blob);
+
+                    if (filename) {
+                        // use HTML5 a[download] attribute to specify filename
+                        var a = document.createElement("a");
+                        // safari doesn't support this yet
+                        if (typeof a.download === 'undefined') {
+                            window.location = downloadUrl;
+                        } else {
+                            a.href = downloadUrl;
+                            a.download = filename;
+                            document.body.appendChild(a);
+                            a.click();
+                        }
+                    } else {
+                        window.location = downloadUrl;
+                    }
+
+                    setTimeout(function () {
+                        URL.revokeObjectURL(downloadUrl);
+                    }, 100); // cleanup
+                }
+            }
+        };
+        xhr.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
+        xhr.send($.param(params));
+    };
+
     var _buildUrl = function(dt, action) {
         var url = dt.ajax.url() || '';
         var params = dt.ajax.params();
@@ -48,6 +106,21 @@
         action: function (e, dt, button, config) {
             var url = _buildUrl(dt, 'csv');
             window.location = url;
+        }
+    };
+
+    DataTable.ext.buttons.exportPostCsv = {
+        className: 'buttons-csv',
+
+        text: function (dt) {
+            return '<i class="fa fa-file-excel-o"></i> ' + dt.i18n('buttons.csv', 'CSV');
+        },
+
+        action: function (e, dt, button, config) {
+            var url = dt.ajax.url() || window.location.href;
+            var params = _buildParams(dt, 'csv');
+
+            _downloadFromUrl(url, params);
         }
     };
 

--- a/src/resources/assets/buttons.server-side.js
+++ b/src/resources/assets/buttons.server-side.js
@@ -109,7 +109,7 @@
         }
     };
 
-    DataTable.ext.buttons.exportPostCsv = {
+    DataTable.ext.buttons.postCsv = {
         className: 'buttons-csv',
 
         text: function (dt) {

--- a/src/resources/assets/buttons.server-side.js
+++ b/src/resources/assets/buttons.server-side.js
@@ -4,7 +4,7 @@
     var _buildParams = function (dt, action) {
         var params = dt.ajax.params();
         params.action = action;
-        params._token = $.fn.dataTable.defaults.csrf_token;
+        params._token = $('meta[name="csrf-token"]').attr('content');
 
         return params;
     };


### PR DESCRIPTION
Use `postCsv` as button. This button is recommended for IE browsers since IE has URL length limit.

<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you read the [Contributing Guidelines](https://github.com/yajra/laravel-datatables-buttons/blob/master/.github/CONTRIBUTING.md)?

If you answered yes, thanks for the PR and we'll get to it ASAP! :)

-->
