### PR TITLE
Change the default export filename

### DIFF
--- a/src/Generators/DataTablesMakeCommand.php
+++ b/src/Generators/DataTablesMakeCommand.php
@@ -186,7 +186,7 @@ class DataTablesMakeCommand extends GeneratorCommand
     protected function replaceFilename(&$stub)
     {
         $stub = str_replace(
-            'DummyFilename', str_slug($this->getNameInput()), $stub
+            'DummyFilename', preg_replace('#datatable$#i', '', $this->getNameInput()), $stub
         );
 
         return $stub;

--- a/src/Generators/stubs/datatables.stub
+++ b/src/Generators/stubs/datatables.stub
@@ -63,6 +63,6 @@ class DummyClass extends DataTable
      */
     protected function filename()
     {
-        return 'DummyFilename_' . time();
+        return 'DummyFilename_' . date('YmdHis');
     }
 }

--- a/src/Services/DataTable.php
+++ b/src/Services/DataTable.php
@@ -373,7 +373,7 @@ abstract class DataTable implements DataTableButtons
      */
     protected function filename()
     {
-        return 'export_' . time();
+        return class_basename($this) . '_' . date('YmdHis');
     }
 
     /**


### PR DESCRIPTION
- Suffixed `date('YmdHis')` instead of `time()`
- Use the original name passed to the make command

For example: `$ php artisan datatables:make AdminUserDataTable`
Old: `adminuserdatatable_1509263506`
New: `AdminUser_20171029075326`

Maybe more readable.