### PR TITLE
Update to Mockery 1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "illuminate/console": "5.4.*|5.5.*"
   },
   "require-dev": {
-    "mockery/mockery": "0.9.*",
+    "mockery/mockery": "~1.0",
     "phpunit/phpunit": "~6.0"
   },
   "autoload": {


### PR DESCRIPTION
Updated `mockery/mockery` to [`~1.0`](https://github.com/mockery/mockery/releases/tag/1.0).

PS: I won't apply [this](https://styleci.io/analyses/Xlo7E9) StycleCI changes. There are not related to this PR :sweat_smile: 