### PR TITLE
Add reset to column search and icons to copy and colvis buttons

### DIFF
--- a/src/resources/assets/buttons.server-side.js
+++ b/src/resources/assets/buttons.server-side.js
@@ -188,7 +188,9 @@
         },
 
         action: function (e, dt, button, config) {
-            dt.search('').draw();
+            dt.search('');
+            dt.columns().search('');
+            dt.draw();
         }
     };
 

--- a/src/resources/assets/buttons.server-side.js
+++ b/src/resources/assets/buttons.server-side.js
@@ -217,4 +217,20 @@
             window.location = window.location.href.replace(/\/+$/, "") + '/create';
         }
     };
+
+    if (typeof DataTable.ext.buttons.copyHtml5 !== 'undefined') {
+        $.extend(DataTable.ext.buttons.copyHtml5, {
+            text: function (dt) {
+                return '<i class="fa fa-copy"></i> ' + dt.i18n('buttons.copy', 'Copy');
+            }
+        });
+    }
+
+    if (typeof DataTable.ext.buttons.colvis !== 'undefined') {
+        $.extend(DataTable.ext.buttons.colvis, {
+            text: function (dt) {
+                return '<i class="fa fa-eye"></i> ' + dt.i18n('buttons.colvis', 'Column visibility');
+            }
+        });
+    }
 })(jQuery, jQuery.fn.dataTable);


### PR DESCRIPTION
I figured it would make sense for the `reset` button to also reset column based searches. Column based search is not yet supported by your package by default, but I guess this could be implemented if necessary. Currently I'm using it for a project and it was rather diffcult to hook into the reset to clear the additional settings. Anyhow, if no column filters are present, it won't hurt - if there are, people will understand my request.

Second change is an addition of button icons for the `copyHtml5` and `colvis` buttons. The `copyHtml5` button will be displayed if the `copy` button is asked for in the datatables config. I added this addition in a way so that it does not change the actual implementation given by datatables.net as this would be rather inconvenient due to the size of some functions. It simply overrides the text property, nothing more.