### PR TITLE
[4.0] Added hasScopes method.

### DIFF
--- a/src/Services/DataTable.php
+++ b/src/Services/DataTable.php
@@ -571,6 +571,23 @@ abstract class DataTable implements DataTableButtons
     }
 
     /**
+     * Determine if the DataTable has scopes.
+     *
+     * @param  array $scopes
+     * @param  bool $validateAll
+     * @return bool
+     */
+    protected function hasScopes(array $scopes, $validateAll = false)
+    {
+        $filteredScopes = array_filter($this->scopes, function ($scope) use ($scopes) {
+            return in_array(get_class($scope), $scopes);
+        });
+
+        return $validateAll ? count($filteredScopes) === count($scopes) :
+            ! empty($filteredScopes);
+    }
+
+    /**
      * Get default builder parameters.
      *
      * @return array


### PR DESCRIPTION
I'm adding `hasScopes` method to check if the current DataTable class has the given scopes.
In my case, I have to determine the columns based on scopes. For example, it the DataTable class has a scope then I need to display A, B and C, otherwise display only A and B.

```php
/**
 * Get columns.
 *
 * @return array
 */
protected function getColumns(): array
{
    $columns = [
        'A',
        'B',
    ];

    if ($this->hasScopes([MyScope::class])) {
        $columns = array_merge(
            $columns,
            [
                'C'
            ]
        );
    }

    return $columns;
}
```

I'm also adding a second parameter to the `hasScopes` method, it's a boolean flag (`false` by default) to set whether to check all the values for true, or to return true if at least one class is matched.

```php
$this->hasScopes([FirstScope::class, SecondScope::class], true)
```

If we pas the second parameter `true`, we will check all the given query scopes for true, it means the DataTable class should have FirstScope and SecondScope class.