### PR TITLE
Change generated model name if option is passed

### DIFF
--- a/src/Generators/DataTablesMakeCommand.php
+++ b/src/Generators/DataTablesMakeCommand.php
@@ -77,7 +77,7 @@ class DataTablesMakeCommand extends GeneratorCommand
         $modelNamespace = $this->option('model-namespace') ? $this->option('model-namespace') : $this->laravel['config']->get('datatables-buttons.namespace.model');
 
         return $model
-            ? $rootNamespace . '\\' . ($modelNamespace ? $modelNamespace . '\\' : '') .  str_singular($name)
+            ? $rootNamespace . '\\' . ($modelNamespace ? $modelNamespace . '\\' : '') .  $this->option('model')
             : $rootNamespace . '\\User';
     }
 


### PR DESCRIPTION
Before, the name of the model was the datatable model itself, instead the model the user was passing with the --model option. Now, if model option is passed, it takes it to generate the model name.

<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you read the [Contributing Guidelines](https://github.com/yajra/laravel-datatables-buttons/blob/master/.github/CONTRIBUTING.md)?

If you answered yes, thanks for the PR and we'll get to it ASAP! :)

-->
