### PR TITLE
[3.x] Allow Laravel 5.4 and up

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "yajra/laravel-datatables-oracle": "8.*",
     "yajra/laravel-datatables-html": "3.*",
     "maatwebsite/excel": "^2.0",
-    "illuminate/console": "5.4.*|5.5.*|5.6.*"
+    "illuminate/console": "^5.4"
   },
   "require-dev": {
     "mockery/mockery": "~1.0",


### PR DESCRIPTION
As Laravel Excel has changed pretty significantly, would it be possible to allow Laravel 5.7 and up to install the 3.x branch?
https://laravel-excel.maatwebsite.nl/3.1/getting-started/upgrade.html#upgrading-to-3-from-2-1

> Version 3.* is not backwards compatible with 2.*. It's not possible to provide a step-by-step migration guide as it's a complete paradigm shift.

Currently we encounter upgrade blocks mostly because of the Excel update, while there shouldn't be any major changes since 5.5. This allows to ease the upgrade process more gently :)