### PR TITLE
remove  buttons.server-side.js path  from /public/vendor to  /public/js

### DIFF
--- a/src/ButtonsServiceProvider.php
+++ b/src/ButtonsServiceProvider.php
@@ -33,7 +33,7 @@ class ButtonsServiceProvider extends ServiceProvider
         ], 'datatables-buttons');
 
         $this->publishes([
-            __DIR__ . '/resources/assets/buttons.server-side.js' => public_path('vendor/datatables/buttons.server-side.js'),
+            __DIR__ . '/resources/assets/buttons.server-side.js' => public_path('js/datatables/buttons.server-side.js'),
         ], 'datatables-buttons');
 
         $this->publishes([


### PR DESCRIPTION
Hi. 
This is my idea, what do you think?

remove  buttons.server-side.js path from /public/vendor to  /public/js

Please understand that English is poor.
<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you read the [Contributing Guidelines](https://github.com/yajra/laravel-datatables-buttons/blob/master/.github/CONTRIBUTING.md)?

If you answered yes, thanks for the PR and we'll get to it ASAP! :)

-->
