### PR TITLE
[4.0] Extract html builder to own class.

### DIFF
--- a/src/ButtonsServiceProvider.php
+++ b/src/ButtonsServiceProvider.php
@@ -4,6 +4,7 @@ namespace Yajra\DataTables;
 
 use Illuminate\Support\ServiceProvider;
 use Maatwebsite\Excel\ExcelServiceProvider;
+use Yajra\DataTables\Generators\DataTablesHtmlCommand;
 use Yajra\DataTables\Generators\DataTablesMakeCommand;
 use Yajra\DataTables\Generators\DataTablesScopeCommand;
 
@@ -48,6 +49,7 @@ class ButtonsServiceProvider extends ServiceProvider
     {
         $this->commands(DataTablesMakeCommand::class);
         $this->commands(DataTablesScopeCommand::class);
+        $this->commands(DataTablesHtmlCommand::class);
     }
 
     /**

--- a/src/Contracts/DataTableHtmlBuilder.php
+++ b/src/Contracts/DataTableHtmlBuilder.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Yajra\DataTables\Contracts;
+
+use Yajra\DataTables\Html\Builder;
+
+interface DataTableHtmlBuilder
+{
+    /**
+     * Handle building of dataTables html.
+     *
+     * @return \Yajra\DataTables\Html\Builder
+     * @throws \Exception
+     */
+    public function handle();
+}

--- a/src/Generators/DataTablesHtmlCommand.php
+++ b/src/Generators/DataTablesHtmlCommand.php
@@ -16,6 +16,7 @@ class DataTablesHtmlCommand extends DataTablesMakeCommand
                             {--dom= : The dom of the datatable.}
                             {--buttons= : The buttons of the datatable.}
                             {--table= : Scaffold columns from the table.}
+                            {--builder : Ignore, added to work with parent generator.}
                             {--columns= : The columns of the datatable.}';
 
     /**

--- a/src/Generators/DataTablesHtmlCommand.php
+++ b/src/Generators/DataTablesHtmlCommand.php
@@ -3,6 +3,7 @@
 namespace Yajra\DataTables\Generators;
 
 use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Console\GeneratorCommand;
 use Symfony\Component\Console\Input\InputOption;
 
@@ -17,6 +18,7 @@ class DataTablesHtmlCommand extends GeneratorCommand
                             {name : The name of the datatable html.}
                             {--dom= : The dom of the datatable.}
                             {--buttons= : The buttons of the datatable.}
+                            {--table= : Scaffold columns from the table.}
                             {--columns= : The columns of the datatable.}';
 
     /**
@@ -168,6 +170,10 @@ class DataTablesHtmlCommand extends GeneratorCommand
      */
     protected function getColumns()
     {
+        if ($this->option('table')) {
+            return $this->parseColumns(Schema::getColumnListing($this->option('table')));
+        }
+
         if ($this->option('columns') != '') {
             return $this->parseColumns($this->option('columns'));
         } else {
@@ -189,7 +195,7 @@ class DataTablesHtmlCommand extends GeneratorCommand
      */
     protected function parseColumns($definition, $indentation = 12)
     {
-        $columns = explode(',', $definition);
+        $columns = is_array($definition) ? $definition : explode(',', $definition);
         $stub    = '';
         foreach ($columns as $key => $column) {
             $stub .= "Column::make('{$column}'),";

--- a/src/Generators/DataTablesHtmlCommand.php
+++ b/src/Generators/DataTablesHtmlCommand.php
@@ -52,6 +52,21 @@ class DataTablesHtmlCommand extends DataTablesMakeCommand
 
         return $stub;
     }
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        $config = $this->laravel['config'];
+
+        return $config->get('datatables-buttons.stub')
+            ? base_path() . $config->get('datatables-buttons.stub') . '/html.stub'
+            : __DIR__ . '/stubs/html.stub';
+    }
+
     /**
      * Parse the name and format according to the root namespace.
      *
@@ -75,19 +90,5 @@ class DataTablesHtmlCommand extends DataTablesMakeCommand
         }
 
         return $this->getDefaultNamespace(trim($rootNamespace, '\\')) . '\\' . $name;
-    }
-
-    /**
-     * Get the stub file for the generator.
-     *
-     * @return string
-     */
-    protected function getStub()
-    {
-        $config = $this->laravel['config'];
-
-        return $config->get('datatables-buttons.stub')
-            ? base_path() . $config->get('datatables-buttons.stub') . '/html.stub'
-            : __DIR__ . '/stubs/html.stub';
     }
 }

--- a/src/Generators/DataTablesHtmlCommand.php
+++ b/src/Generators/DataTablesHtmlCommand.php
@@ -1,0 +1,284 @@
+<?php
+
+namespace Yajra\DataTables\Generators;
+
+use Illuminate\Support\Str;
+use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Input\InputOption;
+
+class DataTablesHtmlCommand extends GeneratorCommand
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'datatables:html
+                            {name : The name of the datatable html.}
+                            {--dom= : The dom of the datatable.}
+                            {--buttons= : The buttons of the datatable.}
+                            {--columns= : The columns of the datatable.}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new dataTable html class.';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'DataTableHtml';
+
+    /**
+     * Build the class with the given name.
+     *
+     * @param string $name
+     * @return string
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+     */
+    protected function buildClass($name)
+    {
+        $stub = parent::buildClass($name);
+
+        return $this->replaceBuilder($stub)
+                    ->replaceColumns($stub)
+                    ->replaceButtons($stub)
+                    ->replaceDOM($stub)
+                    ->replaceTableId($stub);
+    }
+
+    /**
+     * Replace columns.
+     *
+     * @param string $stub
+     * @return string
+     */
+    protected function replaceTableId(&$stub)
+    {
+        $stub = str_replace(
+            'DummyTableId', Str::lower($this->getNameInput()) . '-table', $stub
+        );
+
+        return $stub;
+    }
+
+    /**
+     * Replace dom.
+     *
+     * @param string $stub
+     * @return $this
+     */
+    protected function replaceDOM(&$stub)
+    {
+        $stub = str_replace(
+            'DummyDOM',
+            $this->option('dom') ?: $this->laravel['config']->get('datatables-buttons.generator.dom', 'Bfrtip'),
+            $stub
+        );
+
+        return $this;
+    }
+
+    /**
+     * Replace buttons.
+     *
+     * @param string $stub
+     * @return $this
+     */
+    protected function replaceButtons(&$stub)
+    {
+        $stub = str_replace(
+            'DummyButtons', $this->getButtons(), $stub
+        );
+
+        return $this;
+    }
+
+    /**
+     * Get the columns to be used.
+     *
+     * @return string
+     */
+    protected function getButtons()
+    {
+        if ($this->option('buttons') != '') {
+            return $this->parseButtons($this->option('buttons'));
+        } else {
+            return $this->parseButtons(
+                $this->laravel['config']->get(
+                    'datatables-buttons.generator.buttons',
+                    'create,export,print,reset,reload'
+                )
+            );
+        }
+    }
+
+    /**
+     * Parse array from definition.
+     *
+     * @param string $definition
+     * @param int $indentation
+     * @return string
+     */
+    protected function parseButtons($definition, $indentation = 24)
+    {
+        $columns = explode(',', $definition);
+        $stub    = '';
+        foreach ($columns as $key => $column) {
+            $indent    = '';
+            $separator = ',';
+
+            if ($key < count($columns) - 1) {
+                $indent = PHP_EOL . str_repeat(' ', $indentation);
+            }
+
+            if ($key == count($columns) - 1) {
+                $separator = '';
+            }
+
+            $stub .= "Button::make('{$column}')" . $separator . $indent;
+        }
+
+        return $stub;
+    }
+
+    /**
+     * Replace columns.
+     *
+     * @param string $stub
+     * @return $this
+     */
+    protected function replaceColumns(&$stub)
+    {
+        $stub = str_replace(
+            'DummyColumns', $this->getColumns(), $stub
+        );
+
+        return $this;
+    }
+
+    /**
+     * Get the columns to be used.
+     *
+     * @return string
+     */
+    protected function getColumns()
+    {
+        if ($this->option('columns') != '') {
+            return $this->parseColumns($this->option('columns'));
+        } else {
+            return $this->parseColumns(
+                $this->laravel['config']->get(
+                    'datatables-buttons.generator.columns',
+                    'id,add your columns,created_at,updated_at'
+                )
+            );
+        }
+    }
+
+    /**
+     * Parse array from definition.
+     *
+     * @param string $definition
+     * @param int $indentation
+     * @return string
+     */
+    protected function parseColumns($definition, $indentation = 12)
+    {
+        $columns = explode(',', $definition);
+        $stub    = '';
+        foreach ($columns as $key => $column) {
+            $stub .= "Column::make('{$column}'),";
+
+            if ($key < count($columns) - 1) {
+                $stub .= PHP_EOL . str_repeat(' ', $indentation);
+            }
+        }
+
+        return $stub;
+    }
+
+    /**
+     * Replace builder name.
+     *
+     * @param string $stub
+     * @return self
+     */
+    protected function replaceBuilder(&$stub)
+    {
+        $name  = $this->qualifyClass($this->getNameInput());
+        $class = str_replace($this->getNamespace($name) . '\\', '', $name);
+
+        $stub = str_replace('DummyBuilder', $class . 'Html', $stub);
+
+        return $this;
+    }
+
+    /**
+     * Parse the name and format according to the root namespace.
+     *
+     * @param string $name
+     * @return string
+     */
+    protected function qualifyClass($name)
+    {
+        $rootNamespace = $this->laravel->getNamespace();
+
+        if (Str::startsWith($name, $rootNamespace)) {
+            return $name;
+        }
+
+        if (Str::contains($name, '/')) {
+            $name = str_replace('/', '\\', $name);
+        }
+
+        if (! Str::contains(Str::lower($name), 'datatable')) {
+            $name .= 'DataTableHtml';
+        }
+
+        return $this->getDefaultNamespace(trim($rootNamespace, '\\')) . '\\' . $name;
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param string $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace . '\\' . $this->laravel['config']->get('datatables-buttons.namespace.base', 'DataTables');
+    }
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        $config = $this->laravel['config'];
+
+        return $config->get('datatables-buttons.stub')
+            ? base_path() . $config->get('datatables-buttons.stub') . '/html.stub'
+            : __DIR__ . '/stubs/html.stub';
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['columns', null, InputOption::VALUE_OPTIONAL, 'Use the provided columns.', null],
+            ['buttons', null, InputOption::VALUE_OPTIONAL, 'Use the provided buttons.', null],
+            ['dom', null, InputOption::VALUE_OPTIONAL, 'Use the provided DOM.', null],
+        ];
+    }
+}

--- a/src/Generators/DataTablesHtmlCommand.php
+++ b/src/Generators/DataTablesHtmlCommand.php
@@ -12,19 +12,19 @@ class DataTablesHtmlCommand extends DataTablesMakeCommand
      * @var string
      */
     protected $signature = 'datatables:html
-                            {name : The name of the datatable html.}
-                            {--dom= : The dom of the datatable.}
-                            {--buttons= : The buttons of the datatable.}
+                            {name : The name of the DataTable html.}
+                            {--dom= : The dom of the DataTable.}
+                            {--buttons= : The buttons of the DataTable.}
                             {--table= : Scaffold columns from the table.}
                             {--builder : Ignore, added to work with parent generator.}
-                            {--columns= : The columns of the datatable.}';
+                            {--columns= : The columns of the DataTable.}';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected $description = 'Create a new dataTable html class.';
+    protected $description = 'Create a new DataTable html class.';
 
     /**
      * The type of class being generated.

--- a/src/Generators/DataTablesMakeCommand.php
+++ b/src/Generators/DataTablesMakeCommand.php
@@ -122,7 +122,7 @@ class DataTablesMakeCommand extends GeneratorCommand
      */
     protected function getAction()
     {
-        return $this->option('action') ? $this->option('action') : Str::lower($this->getNameInput()) . '.action';
+        return $this->option('action') ?: Str::lower($this->getNameInput()) . '.action';
     }
 
     /**

--- a/src/Generators/DataTablesMakeCommand.php
+++ b/src/Generators/DataTablesMakeCommand.php
@@ -14,22 +14,22 @@ class DataTablesMakeCommand extends GeneratorCommand
      * @var string
      */
     protected $signature = 'datatables:make
-                            {name : The name of the datatable.}
+                            {name : The name of the DataTable.}
                             {--model= : The name of the model to be used.}
                             {--model-namespace= : The namespace of the model to be used.}
                             {--action= : The path of the action view.}
                             {--table= : Scaffold columns from the table.}
                             {--builder : Extract html() to a Builder class.}
-                            {--dom= : The dom of the datatable.}
-                            {--buttons= : The buttons of the datatable.}
-                            {--columns= : The columns of the datatable.}';
+                            {--dom= : The dom of the DataTable.}
+                            {--buttons= : The buttons of the DataTable.}
+                            {--columns= : The columns of the DataTable.}';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected $description = 'Create a new dataTable service class.';
+    protected $description = 'Create a new DataTable service class.';
 
     /**
      * The type of class being generated.

--- a/src/Generators/DataTablesMakeCommand.php
+++ b/src/Generators/DataTablesMakeCommand.php
@@ -248,14 +248,14 @@ class DataTablesMakeCommand extends GeneratorCommand
 
         if ($this->option('columns') != '') {
             return $this->parseColumns($this->option('columns'));
-        } else {
-            return $this->parseColumns(
-                $this->laravel['config']->get(
-                    'datatables-buttons.generator.columns',
-                    'id,add your columns,created_at,updated_at'
-                )
-            );
         }
+
+        return $this->parseColumns(
+            $this->laravel['config']->get(
+                'datatables-buttons.generator.columns',
+                'id,add your columns,created_at,updated_at'
+            )
+        );
     }
 
     /**

--- a/src/Generators/DataTablesMakeCommand.php
+++ b/src/Generators/DataTablesMakeCommand.php
@@ -15,7 +15,7 @@ class DataTablesMakeCommand extends GeneratorCommand
      */
     protected $signature = 'datatables:make
                             {name : The name of the datatable.}
-                            {--model : The name of the model to be used.}
+                            {--model= : The name of the model to be used.}
                             {--model-namespace= : The namespace of the model to be used.}
                             {--action= : The path of the action view.}
                             {--table= : Scaffold columns from the table.}
@@ -190,8 +190,12 @@ class DataTablesMakeCommand extends GeneratorCommand
     {
         $name           = $this->getNameInput();
         $rootNamespace  = $this->laravel->getNamespace();
-        $model          = $this->option('model') || $this->option('model-namespace');
+        $model          = $this->option('model') == '' || $this->option('model-namespace');
         $modelNamespace = $this->option('model-namespace') ? $this->option('model-namespace') : $this->laravel['config']->get('datatables-buttons.namespace.model');
+
+        if ($this->option('model') != '') {
+            return $this->option('model');
+        }
 
         return $model
             ? $rootNamespace . '\\' . ($modelNamespace ? $modelNamespace . '\\' : '') . Str::singular($name)

--- a/src/Generators/DataTablesMakeCommand.php
+++ b/src/Generators/DataTablesMakeCommand.php
@@ -42,7 +42,7 @@ class DataTablesMakeCommand extends GeneratorCommand
     {
         parent::handle();
 
-        if ($this->hasOption('builder') && $this->option('builder')) {
+        if ($this->option('builder')) {
             $this->call('datatables:html', [
                 'name'      => $this->getNameInput(),
                 '--columns' => $this->option('columns') ?: $this->laravel['config']->get(

--- a/src/Generators/DataTablesMakeCommand.php
+++ b/src/Generators/DataTablesMakeCommand.php
@@ -18,6 +18,7 @@ class DataTablesMakeCommand extends GeneratorCommand
                             {--model : The name of the model to be used.}
                             {--model-namespace= : The namespace of the model to be used.}
                             {--action= : The path of the action view.}
+                            {--table= : Scaffold columns from the table.}
                             {--dom= : The dom of the datatable.}
                             {--buttons= : The buttons of the datatable.}
                             {--columns= : The columns of the datatable.}';
@@ -54,6 +55,7 @@ class DataTablesMakeCommand extends GeneratorCommand
                 'datatables-buttons.generator.dom',
                 'Bfrtip'
             ),
+            '--table'   => $this->option('table'),
         ]);
     }
 

--- a/src/Generators/stubs/builder.stub
+++ b/src/Generators/stubs/builder.stub
@@ -3,11 +3,7 @@
 namespace DummyNamespace;
 
 use DummyModel;
-use Yajra\DataTables\Html\Button;
-use Yajra\DataTables\Html\Column;
 use Yajra\DataTables\Services\DataTable;
-use Yajra\DataTables\Html\Editor\Fields;
-use Yajra\DataTables\Html\Editor\Editor;
 
 class DummyClass extends DataTable
 {
@@ -40,34 +36,9 @@ class DummyClass extends DataTable
      *
      * @return \Yajra\DataTables\Html\Builder
      */
-    public function html()
+    public function htmlBuilder()
     {
-        return $this->builder()
-                    ->setTableId('DummyTableId')
-                    ->columns($this->getColumns())
-                    ->minifiedAjax()
-                    ->dom('DummyDOM')
-                    ->orderBy(1)
-                    ->buttons(
-                        DummyButtons
-                    );
-    }
-
-    /**
-     * Get columns.
-     *
-     * @return array
-     */
-    protected function getColumns()
-    {
-        return [
-            Column::computed('action')
-                  ->exportable(false)
-                  ->printable(false)
-                  ->width(60)
-                  ->addClass('text-center'),
-            DummyColumns
-        ];
+        return DummyBuilder::make();
     }
 
     /**

--- a/src/Generators/stubs/datatables.stub
+++ b/src/Generators/stubs/datatables.stub
@@ -15,7 +15,8 @@ class DummyClass extends DataTable
      */
     public function dataTable($query)
     {
-        return datatables($query)
+        return datatables()
+            ->eloquent($query)
             ->addColumn('action', 'DummyAction');
     }
 
@@ -27,33 +28,17 @@ class DummyClass extends DataTable
      */
     public function query(ModelName $model)
     {
-        return $model->newQuery()->select('id', 'add-your-columns-here', 'created_at', 'updated_at');
+        return $model->newQuery();
     }
 
     /**
      * Optional method if you want to use html builder.
      *
-     * @return \Yajra\DataTables\Html\Builder
+     * @return \Yajra\DataTables\Html\Builder|DummyBuilder
      */
-    public function html()
+    public function htmlBuilder()
     {
-        return $this->builder()
-                    ->columns($this->getColumns())
-                    ->minifiedAjax()
-                    ->addAction(['width' => '80px'])
-                    ->parameters($this->getBuilderParameters());
-    }
-
-    /**
-     * Get columns.
-     *
-     * @return array
-     */
-    protected function getColumns()
-    {
-        return [
-            'DummyColumns'
-        ];
+        return DummyBuilder::make();
     }
 
     /**

--- a/src/Generators/stubs/html.stub
+++ b/src/Generators/stubs/html.stub
@@ -5,6 +5,8 @@ namespace DummyNamespace;
 use Yajra\DataTables\Html\Button;
 use Yajra\DataTables\Html\Column;
 use Yajra\DataTables\Html\DataTableHtml;
+use Yajra\DataTables\Html\Editor\Fields;
+use Yajra\DataTables\Html\Editor\Editor;
 
 class DummyClass extends DataTableHtml
 {

--- a/src/Generators/stubs/html.stub
+++ b/src/Generators/stubs/html.stub
@@ -1,0 +1,43 @@
+<?php
+
+namespace DummyNamespace;
+
+use Yajra\DataTables\Html\Button;
+use Yajra\DataTables\Html\Column;
+use Yajra\DataTables\Html\DataTableHtml;
+
+class DummyClass extends DataTableHtml
+{
+    /**
+     * Build the html builder.
+     *
+     * @return \Yajra\DataTables\Html\Builder
+     * @throws \Exception
+     */
+    public function handle()
+    {
+        return $this->setTableId('DummyTableId')
+                    ->columns($this->getColumns())
+                    ->minifiedAjax()
+                    ->dom('DummyDOM')
+                    ->orderBy(1)
+                    ->buttons(
+                        DummyButtons
+                    );
+    }
+
+    /**
+     * @return array
+     */
+    protected function getColumns()
+    {
+        return [
+            Column::computed('action')
+                  ->exportable(false)
+                  ->printable(false)
+                  ->width(60)
+                  ->addClass('text-center'),
+            DummyColumns
+        ];
+    }
+}

--- a/src/Html/DataTableHtml.php
+++ b/src/Html/DataTableHtml.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Yajra\DataTables\Html;
+
+use BadMethodCallException;
+use Yajra\DataTables\Contracts\DataTableHtmlBuilder;
+
+/**
+ * @mixin Builder
+ */
+abstract class DataTableHtml implements DataTableHtmlBuilder
+{
+    /**
+     * @var \Yajra\DataTables\Html\Builder
+     */
+    protected $htmlBuilder;
+
+    /**
+     * @return \Yajra\DataTables\Html\Builder
+     */
+    public static function make()
+    {
+        return app(static::class)->handle();
+    }
+
+    /**
+     * @param string $name
+     * @param mixed $arguments
+     * @return mixed
+     * @throws \Exception
+     */
+    public function __call($name, $arguments)
+    {
+        if (method_exists($this->getHtmlBuilder(), $name)) {
+            return $this->getHtmlBuilder()->{$name}(...$arguments);
+        }
+
+        throw new BadMethodCallException("Method {$name} does not exists");
+    }
+
+    /**
+     * @return \Yajra\DataTables\Html\Builder
+     */
+    protected function getHtmlBuilder()
+    {
+        if ($this->htmlBuilder) {
+            return $this->htmlBuilder;
+        }
+
+        return $this->htmlBuilder = app(Builder::class);
+    }
+
+    /**
+     * @param mixed $builder
+     * @return static
+     */
+    public function setHtmlBuilder($builder)
+    {
+        $this->htmlBuilder = $builder;
+
+        return $this;
+    }
+}

--- a/src/Services/DataTable.php
+++ b/src/Services/DataTable.php
@@ -289,7 +289,15 @@ abstract class DataTable implements DataTableButtons
      */
     public function builder()
     {
-        return $this->htmlBuilder ?: $this->htmlBuilder = app('datatables.html');
+        if ($this->htmlBuilder) {
+            return $this->htmlBuilder;
+        }
+
+        if (method_exists($this, 'htmlBuilder')) {
+            return $this->htmlBuilder = app()->call([$this, 'htmlBuilder']);
+        }
+
+        return $this->htmlBuilder = app('datatables.html');
     }
 
     /**

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -4,7 +4,7 @@ return [
     /*
      * Namespaces used by the generator.
      */
-    'namespace' => [
+    'namespace'     => [
         /*
          * Base namespace/directory to create the new file.
          * This is appended on default Laravel namespace.
@@ -13,7 +13,7 @@ return [
          * With Model: App\User (default model)
          * Export filename: users_timestamp
          */
-        'base' => 'DataTables',
+        'base'  => 'DataTables',
 
         /*
          * Base namespace/directory where your model's are located.
@@ -42,8 +42,8 @@ return [
     /*
      * Snappy PDF options.
      */
-    'snappy' => [
-        'options' => [
+    'snappy'        => [
+        'options'     => [
             'no-outline'    => true,
             'margin-left'   => '0',
             'margin-right'  => '0',
@@ -56,7 +56,7 @@ return [
     /*
      * Default html builder parameters.
      */
-    'parameters' => [
+    'parameters'    => [
         'dom'     => 'Bfrtip',
         'order'   => [[0, 'desc']],
         'buttons' => [
@@ -66,5 +66,25 @@ return [
             'reset',
             'reload',
         ],
+    ],
+
+    /**
+     * Generator command default options value.
+     */
+    'generator'     => [
+        /**
+         * Default columns to generate when not set.
+         */
+        'columns' => 'id,add your columns,created_at,updated_at',
+
+        /**
+         * Default buttons to generate when not set.
+         */
+        'buttons' => 'create,export,print,reset,reload',
+
+        /**
+         * Default DOM to generate when not set.
+         */
+        'dom' => 'Bfrtip',
     ],
 ];


### PR DESCRIPTION
This PR aims to extract the `html()` method of DataTable service to its own class with the following changes:

1. Add `htmlBuider()` method that will return a `Builder` class.
2. Add generator command `datatables:html` to generate the Html Builder class.
3. Replace `html()` with `htmlBuilder()` when using the generator `datatables:make --builder` command.
4. `datatables:make --builder` command will now generate 2 files. One for the service class and one for html builder class.
5. This will also address issue for multiple dataTables rending as discussed on https://github.com/yajra/laravel-datatables/pull/995.
6. Stubs were updated to promote the fluent api and `Column` and `Button` class.

## DataTables Html Command

The command below will generate `UsersDataTableHtml` class with some options as needed.

```sh
> php artisan datatables:html Users
> php artisan datatables:html Users --dom=Bfrtip --columns=id,name --buttons=csv,print
```

### OUTPUT
```php
<?php

namespace App\DataTables;

use Yajra\DataTables\Html\Button;
use Yajra\DataTables\Html\Column;
use Yajra\DataTables\Html\DataTableHtml;

class UsersDataTableHtml extends DataTableHtml
{
    /**
     * Build the html builder.
     *
     * @return \Yajra\DataTables\Html\Builder
     * @throws \Exception
     */
    public function handle()
    {
        return $this->setTableId('users-table')
                    ->columns($this->getColumns())
                    ->minifiedAjax()
                    ->dom('Bfrtip')
                    ->orderBy(1)
                    ->buttons(
                        Button::make('csv'),
                        Button::make('print')
                    );
    }

    /**
     * @return array
     */
    protected function getColumns()
    {
        return [
            Column::computed('action')
                  ->exportable(false)
                  ->printable(false)
                  ->width(60)
                  ->addClass('text-center'),
            Column::make('id'),
            Column::make('name'),
        ];
    }
}
```

## DataTables Make Command

The command below will generate  `UsersDataTable` and `UsersDataTableHtml` class with some options as needed.

```sh
> php artisan datatables:make Users
> php artisan datatables:make Users --dom=Bfrtip --columns=id,name --buttons=csv,print
```

### OUTPUT

```php
<?php

namespace App\DataTables;

use App\User;
use Yajra\DataTables\Services\DataTable;

class UsersDataTable extends DataTable
{
    /**
     * Build DataTable class.
     *
     * @param mixed $query Results from query() method.
     * @return \Yajra\DataTables\DataTableAbstract
     */
    public function dataTable($query)
    {
        return datatables()
            ->eloquent($query)
            ->addColumn('action', 'users.action');
    }

    /**
     * Get query source of dataTable.
     *
     * @param \App\User $model
     * @return \Illuminate\Database\Eloquent\Builder
     */
    public function query(User $model)
    {
        return $model->newQuery();
    }

    /**
     * Optional method if you want to use html builder.
     *
     * @return \Yajra\DataTables\Html\Builder|UsersDataTableHtml
     */
    public function htmlBuilder()
    {
        return UsersDataTableHtml::make();
    }

    /**
     * Get filename for export.
     *
     * @return string
     */
    protected function filename()
    {
        return 'Users_' . date('YmdHis');
    }
}
```
