### PR TITLE
Fix BindingResolutionException when using Laravel 7.7.0 or greater

### DIFF
--- a/src/Services/DataTable.php
+++ b/src/Services/DataTable.php
@@ -186,14 +186,14 @@ abstract class DataTable implements DataTableButtons
      */
     public function ajax()
     {
-        $source = null;
+        $query = null;
         if (method_exists($this, 'query')) {
-            $source = app()->call([$this, 'query']);
-            $source = $this->applyScopes($source);
+            $query = app()->call([$this, 'query']);
+            $query = $this->applyScopes($query);
         }
 
         /** @var \Yajra\DataTables\DataTableAbstract $dataTable */
-        $dataTable = app()->call([$this, 'dataTable'], compact('source'));
+        $dataTable = app()->call([$this, 'dataTable'], compact('query'));
 
         if ($callback = $this->beforeCallback) {
             $callback($dataTable);


### PR DESCRIPTION
Starting in Laravel 7.7.0, a BindingResolutionException is thrown when a required parameter is not found. When implementing laravel-datatables as a service, the query parameter is used in the extended classes. 
However, in the DataTable service, the parameter is called "source". This throws an exception as the required variable "query" is missing. I have changed the variable name to "query" to fix this.

Let me know, if you have any questions.

Fixes https://github.com/yajra/laravel-datatables/issues/2375

Thanks!