### PR TITLE
Make use of default html builder parameters.

### DIFF
--- a/src/Generators/stubs/builder.stub
+++ b/src/Generators/stubs/builder.stub
@@ -38,7 +38,8 @@ class DummyClass extends DataTable
      */
     public function htmlBuilder()
     {
-        return DummyBuilder::make();
+        return DummyBuilder::make()
+            ->parameters($this->getBuilderParameters());
     }
 
     /**

--- a/src/Generators/stubs/datatables.stub
+++ b/src/Generators/stubs/datatables.stub
@@ -43,6 +43,7 @@ class DummyClass extends DataTable
     public function html()
     {
         return $this->builder()
+                    ->parameters($this->getBuilderParameters())
                     ->setTableId('DummyTableId')
                     ->columns($this->getColumns())
                     ->minifiedAjax()

--- a/src/Services/DataTable.php
+++ b/src/Services/DataTable.php
@@ -279,7 +279,8 @@ abstract class DataTable implements DataTableButtons
      */
     public function html()
     {
-        return $this->builder();
+        return $this->builder()
+            ->parameters($this->getBuilderParameters());
     }
 
     /**


### PR DESCRIPTION
In my opinion, it is confusing when default values are set in the configuration file but are not applied by default. For this reason, it would make sense to apply these default values.