### PR TITLE
Use Blade's helper to check for the first row

### DIFF
--- a/src/resources/views/print.blade.php
+++ b/src/resources/views/print.blade.php
@@ -15,7 +15,7 @@
     <body>
         <table class="table table-bordered table-condensed table-striped">
             @foreach($data as $row)
-                @if ($row == reset($data)) 
+                @if ($loop->first)
                     <tr>
                         @foreach($row as $key => $value)
                             <th>{!! $key !!}</th>


### PR DESCRIPTION
I had a table where the first 3 rows were identical.

Because of the `reset` call I had the header displayed three times.

Using Blade's `first` helper solves it and is working from Laravel 5.3.

https://laravel.com/docs/5.3/blade#the-loop-variable