### PR TITLE
Added support for Laravel 8.x if Models directory exists.

### DIFF
--- a/src/Generators/DataTablesMakeCommand.php
+++ b/src/Generators/DataTablesMakeCommand.php
@@ -362,7 +362,7 @@ class DataTablesMakeCommand extends GeneratorCommand
         }
 
         // check if model namespace is not set in command and Models directory already exists then use that directory in namespace.
-        if($modelNamespace == '') {
+        if ($modelNamespace == '') {
             $modelNamespace = is_dir(app_path('Models')) ? 'Models' : $rootNamespace;
         }
 

--- a/src/Generators/DataTablesMakeCommand.php
+++ b/src/Generators/DataTablesMakeCommand.php
@@ -361,6 +361,11 @@ class DataTablesMakeCommand extends GeneratorCommand
             return $this->option('model');
         }
 
+        // check if model namespace is not set in command and Models directory already exists then use that directory in namespace.
+        if($modelNamespace == '') {
+            $modelNamespace = is_dir(app_path('Models')) ? 'Models' : $rootNamespace;
+        }
+
         return $model
             ? $rootNamespace . '\\' . ($modelNamespace ? $modelNamespace . '\\' : '') . Str::singular($name)
             : $rootNamespace . '\\User';


### PR DESCRIPTION
added support for Laravel 8.x if Models directory exists then use Models directory in namespace for model

PR for the issue [Pointing to wrong model path when generating DataTable - Laravel 8](https://github.com/yajra/laravel-datatables/issues/2468)
