### PR TITLE
Set the start to 0 on export

### DIFF
--- a/src/Services/DataTable.php
+++ b/src/Services/DataTable.php
@@ -323,7 +323,10 @@ abstract class DataTable implements DataTableButtons
      */
     protected function getAjaxResponseData()
     {
-        $this->request()->merge(['length' => -1]);
+        $this->request()->merge([
+            'start' => 0,
+            'length' => -1
+        ]);
 
         $response = app()->call([$this, 'ajax']);
         $data     = $response->getData(true);

--- a/src/Services/DataTable.php
+++ b/src/Services/DataTable.php
@@ -325,7 +325,7 @@ abstract class DataTable implements DataTableButtons
     {
         $this->request()->merge([
             'start' => 0,
-            'length' => -1
+            'length' => -1,
         ]);
 
         $response = app()->call([$this, 'ajax']);

--- a/src/Services/DataTable.php
+++ b/src/Services/DataTable.php
@@ -324,7 +324,7 @@ abstract class DataTable implements DataTableButtons
     protected function getAjaxResponseData()
     {
         $this->request()->merge([
-            'start' => 0,
+            'start'  => 0,
             'length' => -1,
         ]);
 


### PR DESCRIPTION
If we don't set the start to 0, if we're press the export button from page > 1, and we're displaying row index, the row index will completely wrong.
