### PR TITLE
Request expects JSON

### DIFF
--- a/src/Services/DataTable.php
+++ b/src/Services/DataTable.php
@@ -154,7 +154,7 @@ abstract class DataTable implements DataTableButtons
      */
     public function render($view, $data = [], $mergeData = [])
     {
-        if ($this->request()->ajax() && $this->request()->wantsJson()) {
+        if ($this->request()->expectsJson()) {
             return app()->call([$this, 'ajax']);
         }
 


### PR DESCRIPTION
Improve how to determine if the current request probably expects a JSON response.

That following test can be simplified be adapting [`$request->expectsJson()`](https://github.com/laravel/framework/blob/master/src/Illuminate/Http/Concerns/InteractsWithContentTypes.php#L24)

```diff
 public function test_a_user_can_view_any_users()
 {
     $user = User::factory()->create();

-    $jsonResponse = $this->actingAs($user)
-        ->withHeaders([
-            'Accept' => 'application/json',
-            'X-Requested-With' => 'XMLHttpRequest',
-        ])
-        ->get(route('users.index'));

+    $jsonResponse = $this->actingAs($user)->json('GET', route('users.index'));

     $jsonResponse->assertSuccessful();

     $this->assertArrayNotHasKey('error', $jsonResponse->getData(true));
 }
```

<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you read the [Contributing Guidelines](https://github.com/yajra/laravel-datatables-buttons/blob/master/.github/CONTRIBUTING.md)?

If you answered yes, thanks for the PR and we'll get to it ASAP! :)

-->
