### PR TITLE
[4.x] Improve support for custom laravel-excel export class using collection.

### DIFF
--- a/src/Exports/DataTablesCollectionExport
+++ b/src/Exports/DataTablesCollectionExport
@@ -1,0 +1,47 @@
+<?php
+
+namespace Yajra\DataTables\Exports;
+
+use Illuminate\Support\Collection;
+use Maatwebsite\Excel\Concerns\Exportable;
+use Maatwebsite\Excel\Concerns\FromCollection;
+use Maatwebsite\Excel\Concerns\WithHeadings;
+
+abstract class DataTablesCollectionExport implements  FromCollection, WithHeadings
+{
+    use Exportable;
+
+    /**
+     * @var Collection
+     */
+    protected $collection;
+
+    /**
+     * @param Collection $collection
+     */
+    public function __construct(Collection $collection)
+    {
+        $this->collection = $collection;
+    }
+
+    /**
+     * @return Collection
+     */
+    public function collection()
+    {
+        return $this->collection;
+    }
+
+    /**
+     * @return array
+     */
+    public function headings(): array
+    {
+        $first = $this->collection->first();
+        if ($first) {
+            return array_keys($first);
+        }
+
+        return [];
+    }
+}

--- a/src/Services/DataTable.php
+++ b/src/Services/DataTable.php
@@ -405,9 +405,17 @@ abstract class DataTable implements DataTableButtons
      */
     protected function buildExcelFile()
     {
-        $dataForExport = collect($this->getDataForExport());
+        if ($this->exportClass <> DataTablesExportHandler::class) {
+            $collection = collect($this->getAjaxResponseData());
+        } else {
+            $collection = collect($this->getDataForExport());
+        }
 
-        return new $this->exportClass($dataForExport);
+        if (method_exists($collection, 'lazy')) {
+            $collection->lazy();
+        }
+
+        return new $this->exportClass($collection);
     }
 
     /**

--- a/src/Services/DataTablesExportHandler.php
+++ b/src/Services/DataTablesExportHandler.php
@@ -2,10 +2,6 @@
 
 namespace Yajra\DataTables\Services;
 
-use Illuminate\Support\Collection;
-use Maatwebsite\Excel\Concerns\Exportable;
-use Maatwebsite\Excel\Concerns\FromCollection;
-use Maatwebsite\Excel\Concerns\WithHeadings;
 use Yajra\DataTables\Exports\DataTablesCollectionExport;
 
 class DataTablesExportHandler extends DataTablesCollectionExport

--- a/src/Services/DataTablesExportHandler.php
+++ b/src/Services/DataTablesExportHandler.php
@@ -6,44 +6,9 @@ use Illuminate\Support\Collection;
 use Maatwebsite\Excel\Concerns\Exportable;
 use Maatwebsite\Excel\Concerns\FromCollection;
 use Maatwebsite\Excel\Concerns\WithHeadings;
+use Yajra\DataTables\Exports\DataTablesCollectionExport;
 
-class DataTablesExportHandler implements FromCollection, WithHeadings
+class DataTablesExportHandler extends DataTablesCollectionExport
 {
-    use Exportable;
 
-    /**
-     * @var Collection
-     */
-    protected $collection;
-
-    /**
-     * DataTablesExportHandler constructor.
-     *
-     * @param Collection $collection
-     */
-    public function __construct(Collection $collection)
-    {
-        $this->collection = $collection;
-    }
-
-    /**
-     * @return Collection
-     */
-    public function collection()
-    {
-        return $this->collection;
-    }
-
-    /**
-     * @return array
-     */
-    public function headings(): array
-    {
-        $first = $this->collection->first();
-        if ($first) {
-            return array_keys($first);
-        }
-
-        return [];
-    }
 }


### PR DESCRIPTION
This PR will improve support for the `laravel-excel` package export class.

1. All rows will now be included instead of the filtered values displayed in the table. (Potential breaking change)
2. Add `DataTablesCollectionExport` abstract class.

## Example Usage

1. Create an export class `php artisan make:export UsersExport`
2. Update the generated export class and extend `DataTablesCollectionExport`

```php
namespace App\Exports;

use Yajra\DataTables\Exports\DataTablesCollectionExport;

class UsersExport extends DataTablesCollectionExport
{
    
}
```

3. Update your `UsersDataTable` class and set `protected $exportClass = UsersExport::class`

```php
class UsersDataTable extends DataTable
{
    protected $exportClass = UsersExport::class;

```

4. Update your export class as needed. See official package docs: https://docs.laravel-excel.com/3.1/exports/collection.html

## Example Export Class

```php
<?php

namespace App\Exports;

use Maatwebsite\Excel\Concerns\WithMapping;
use Yajra\DataTables\Services\DataTablesExportHandler;

class UsersExport extends DataTablesCollectionExport implements WithMapping
{
    public function headings(): array
    {
        return [
            'Name',
            'Email',
        ];
    }

    public function map($row): array
    {
        return [
            $row['name'],
            $row['email'],
        ];
    }
}
```
