### PR TITLE
Use same export data if export handler extends DataTablesExportHandler

### DIFF
--- a/src/Services/DataTable.php
+++ b/src/Services/DataTable.php
@@ -433,7 +433,7 @@ abstract class DataTable implements DataTableButtons
             return $this->buildFastExcelFile();
         }
 
-        if ($this->exportClass != DataTablesExportHandler::class) {
+        if (! is_subclass_of($this->exportClass, DataTablesExportHandler::class)) {
             $collection = $this->getAjaxResponseData();
 
             return new $this->exportClass($this->convertToLazyCollection($collection));


### PR DESCRIPTION
This PR makes sure that if you're using a custom export handler which extends the default DataTablesExportHandler, it receives the same data that the default export handler would receive.
This fixes a BC introduced on commit 45c7faf957e10cbfdfa0424d2f0b0765fbb1fd5a (see issue #126)

