### PR TITLE
[4.x] Allow passing of constructor arguments on make method helper.

### DIFF
--- a/src/Html/DataTableHtml.php
+++ b/src/Html/DataTableHtml.php
@@ -20,6 +20,10 @@ abstract class DataTableHtml implements DataTableHtmlBuilder
      */
     public static function make()
     {
+        if (func_get_args()) {
+            return (new static(...func_get_args()))->handle();
+        }
+
         return app(static::class)->handle();
     }
 


### PR DESCRIPTION
This PR will allow `make` factory helper to accept constructor arguments like how Laravel's `Event::dispatch()` works.

```php
class ProjectMembersDataTableHtml extends DataTableHtml
{
    public $project;

    public function __construct(Project $project)
    {
        $this->project = $project;
    }
...
```

Before PR:

```php
$members = (new ProjectMembersDataTableHtml($project))->handle();
```

After PR:

```php
$members = ProjectMembersDataTableHtml::make($project);
```