### PR TITLE
[4x.] Fix addScopes method pushing the array of scopes.

### DIFF
--- a/src/Services/DataTable.php
+++ b/src/Services/DataTable.php
@@ -550,7 +550,7 @@ abstract class DataTable implements DataTableButtons
      */
     public function addScopes(array $scopes)
     {
-        array_merge($this->scopes, $scopes);
+        $this->scopes = array_merge($this->scopes, $scopes);
 
         return $this;
     }

--- a/src/Services/DataTable.php
+++ b/src/Services/DataTable.php
@@ -550,7 +550,7 @@ abstract class DataTable implements DataTableButtons
      */
     public function addScopes(array $scopes)
     {
-        array_push($this->scopes, $scopes);
+        array_merge($this->scopes, $scopes);
 
         return $this;
     }


### PR DESCRIPTION
Hi! 

I'm trying to use the `addScopes` in a base class, but sounds like it's creating a array of array of scopes and not a list of scopes like in multiple calls of `addScope`.

BTW thanks for the package. I love it.