### PR TITLE
FastExcel Integration: Use data as source.

### DIFF
--- a/src/Services/DataTable.php
+++ b/src/Services/DataTable.php
@@ -694,7 +694,7 @@ abstract class DataTable implements DataTableButtons
             $mapped = [];
             foreach ($this->exportColumns() as $column) {
                 if ($column['exportable']) {
-                    $mapped[$column['title']] = $row[$column['name']];
+                    $mapped[$column['title']] = $row[$column['data']];
                 }
             }
 


### PR DESCRIPTION
FastExcel Integration: Use data as source since integration relies on SQL field name / alias.

