### PR TITLE
Package `maatwebsite/excel` still being installed when you want to use `fast-excel` (or another Excel-package)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,16 +18,11 @@
     "php": ">=7.0",
     "yajra/laravel-datatables-oracle": "8.*|9.*",
     "yajra/laravel-datatables-html": "3.*|4.*",
-    "maatwebsite/excel": "^3.0",
     "illuminate/console": "*"
   },
   "require-dev": {
     "mockery/mockery": "~1.0",
     "phpunit/phpunit": "~7.0"
-  },
-  "suggest": {
-    "rap2hpoutre/fast-excel": "Faster exporting of dataTables using fast-excel package.",
-    "barryvdh/laravel-snappy": "For exporting of dataTables to PDF."
   },
   "autoload": {
     "psr-4": {
@@ -50,6 +45,8 @@
     }
   },
   "suggest": {
+    "maatwebsite/excel": "Exporting of dataTables (excel, csv and PDF) using maatwebsite package.",
+    "rap2hpoutre/fast-excel": "Faster exporting of dataTables using fast-excel package.",
     "dompdf/dompdf": "Allows exporting of dataTable to PDF using the DomPDF.",
     "barryvdh/laravel-snappy": "Allows exporting of dataTable to PDF using the print view."
   },

--- a/src/ButtonsServiceProvider.php
+++ b/src/ButtonsServiceProvider.php
@@ -62,6 +62,9 @@ class ButtonsServiceProvider extends ServiceProvider
         $this->mergeConfigFrom(__DIR__ . '/config/config.php', 'datatables-buttons');
 
         $this->app->register(HtmlServiceProvider::class);
-        $this->app->register(ExcelServiceProvider::class);
+
+        if (class_exists(ExcelServiceProvider::class)) {
+            $this->app->register(ExcelServiceProvider::class);
+        }
     }
 }

--- a/src/Services/DataTable.php
+++ b/src/Services/DataTable.php
@@ -433,6 +433,10 @@ abstract class DataTable implements DataTableButtons
             return $this->buildFastExcelFile();
         }
 
+        if (! class_exists(\Maatwebsite\Excel\ExcelServiceProvider::class)) {
+            throw new \Exception('Please install maatwebsite/excel to be able to use this function.');
+        }
+
         if (! new $this->exportClass(collect()) instanceof DataTablesExportHandler) {
             $collection = $this->getAjaxResponseData();
 


### PR DESCRIPTION
Hi,

When you want to use the `fast-excel` package (or another Excel-package) instead of `maatwebsite/excel`, this package will be still installed due it's being installed in the root-required selection.

It's better to move `maatwebsite/excel` to the suggest selection, so we can pick-up one of the suggestions instead. 

Technically this /is/ a breaking change, but I don't know which branch you are using for v5, since master is little bit behind already.