### PR TITLE
DataArrayTransformer Trim decoded content

### DIFF
--- a/src/Transformers/DataArrayTransformer.php
+++ b/src/Transformers/DataArrayTransformer.php
@@ -62,7 +62,7 @@ class DataArrayTransformer
     protected function decodeContent($data)
     {
         try {
-            $decoded = html_entity_decode(strip_tags($data), ENT_QUOTES, 'UTF-8');
+            $decoded = html_entity_decode(trim(strip_tags($data)), ENT_QUOTES, 'UTF-8');
 
             return str_replace("\xc2\xa0", ' ', $decoded);
         } catch (\Throwable $e) {


### PR DESCRIPTION
Hi there :)

When exporting data, I often encounter a blank spaces problem around the value after removing the HTML tags (via strip_tags()).
A quick solution to this problem would be to simply trim() this content.

Thanks!