### PR TITLE
[10.x] Fix scopes for Eloquent Relation - Exception: "TypeError"

### DIFF
--- a/src/Contracts/DataTableScope.php
+++ b/src/Contracts/DataTableScope.php
@@ -7,7 +7,7 @@ interface DataTableScope
     /**
      * Apply a query scope.
      *
-     * @param  \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder  $query
+     * @param  \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Eloquent\Relations\Relation  $query
      * @return mixed
      */
     public function apply($query);

--- a/src/Services/DataTable.php
+++ b/src/Services/DataTable.php
@@ -22,6 +22,7 @@ use Yajra\DataTables\Html\Column;
 use Yajra\DataTables\QueryDataTable;
 use Yajra\DataTables\Transformers\DataArrayTransformer;
 use Yajra\DataTables\Utilities\Request;
+use Illuminate\Database\Eloquent\Relations\Relation as EloquentRelation;
 
 abstract class DataTable implements DataTableButtons
 {
@@ -243,7 +244,7 @@ abstract class DataTable implements DataTableButtons
     {
         $query = null;
         if (method_exists($this, 'query')) {
-            /** @var EloquentBuilder|QueryBuilder $query */
+            /** @var EloquentBuilder|QueryBuilder|EloquentRelation $query */
             $query = app()->call([$this, 'query']);
             $query = $this->applyScopes($query);
         }
@@ -713,10 +714,10 @@ abstract class DataTable implements DataTableButtons
     /**
      * Apply query scopes.
      *
-     * @param  EloquentBuilder|QueryBuilder  $query
-     * @return EloquentBuilder|QueryBuilder
+     * @param  EloquentBuilder|QueryBuilder|EloquentRelation  $query
+     * @return EloquentBuilder|QueryBuilder|EloquentRelation
      */
-    protected function applyScopes(EloquentBuilder|QueryBuilder $query): EloquentBuilder|QueryBuilder
+    protected function applyScopes(EloquentBuilder|QueryBuilder|EloquentRelation $query): EloquentBuilder|QueryBuilder|EloquentRelation
     {
         foreach ($this->scopes as $scope) {
             $scope->apply($query);

--- a/src/Services/DataTable.php
+++ b/src/Services/DataTable.php
@@ -7,6 +7,7 @@ use Closure;
 use Generator;
 use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Database\Eloquent\Relations\Relation as EloquentRelation;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Response;
@@ -22,7 +23,6 @@ use Yajra\DataTables\Html\Column;
 use Yajra\DataTables\QueryDataTable;
 use Yajra\DataTables\Transformers\DataArrayTransformer;
 use Yajra\DataTables\Utilities\Request;
-use Illuminate\Database\Eloquent\Relations\Relation as EloquentRelation;
 
 abstract class DataTable implements DataTableButtons
 {


### PR DESCRIPTION
I have upgraded from v4 and the following instruction throws the exception "TypeError" because the input parameter of the applyScopes() function can be of type Relation and the returned value can also be of type Relation.


`$returnHTML = $dataTable->with(["model" => $model])->render('backend.media.get_media_datatables', $data);
`
```
exception: "TypeError"
file: "/var/app/current/vendor/yajra/laravel-datatables-buttons/src/Services/DataTable.php"
line: 719
message: "Yajra\\DataTables\\Services\\DataTable::applyScopes(): Argument #1 ($query) must be of type Illuminate\\Database\\Eloquent\\Builder|Illuminate\\Database\\Query\\Builder, Illuminate\\Database\\Eloquent\\Relations\\MorphMany given, called in /var/app/current/vendor/yajra/laravel-datatables-buttons/src/Services/DataTable.php on line 248"
trace: [,…]
0: {file: "/var/app/current/vendor/yajra/laravel-datatables-buttons/src/Services/DataTable.php",…}
1: {file: "/var/app/current/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php",…}
2: {file: "/var/app/current/vendor/laravel/framework/src/Illuminate/Container/Util.php", line: 41,…}
3: {file: "/var/app/current/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php",…}
4: {file: "/var/app/current/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php",…}
5: {file: "/var/app/current/vendor/laravel/framework/src/Illuminate/Container/Container.php",…}
6: {file: "/var/app/current/vendor/yajra/laravel-datatables-buttons/src/Services/DataTable.php",…}
7: {file: "/var/app/current/app/Http/Controllers/Backend/MediaController.php", line: 52,…}
```