### PR TITLE
Fixes some issues and confusion of datatable generator command

### DIFF
--- a/src/Generators/DataTablesHtmlCommand.php
+++ b/src/Generators/DataTablesHtmlCommand.php
@@ -86,8 +86,10 @@ class DataTablesHtmlCommand extends DataTablesMakeCommand
             $name = str_replace('/', '\\', $name);
         }
 
-        if (! Str::contains(Str::lower($name), 'datatable')) {
+        if (! Str::contains(Str::lower($name), 'datatablehtml')) {
             $name .= 'DataTableHtml';
+        } else {
+            $name = preg_replace('#datatablehtml$#i', 'DataTableHtml', $name);
         }
 
         return $this->getDefaultNamespace(trim($rootNamespace, '\\')).'\\'.$name;


### PR DESCRIPTION
This pull request fixes plethora of issues for the `datatables:make` command -
1. Fixes `datatables:make` command fail to generate error free classes for the following scenarios where it can't identify the model name and namespace correctly -
    - `php artisan datatables:make Api/DriverDataTable`
    - `php artisan datatables:make Api/Driverdatatable`
    - `php artisan datatables:make Api/Driver`
    - `php artisan datatables:make Api/DriverDataTable --model=Driver`
    - `php artisan datatables:make Api/DriverDataTable --model=Driver --model-namespace=App\\Custom`
    - `php artisan datatables:make Api/DriverDataTable --builder`
2. Fixes appending `DataTable` with mix-case or lowercase generating different class name.
4. In `datatables:make` command, the `getModel()` method was too confusing. Tried to simplify the logic and removed code duplication. Such as, there's no need to check for -
    - Existence of `Models` directory and 
    - Root namespace when model namespace is provided by the user (either in config or in arguments).
6. Fixes where  `datatables:make --builder` command will always fail to create HTML builder class.