### PR TITLE
fix: applyScopes method to support Collection

### DIFF
--- a/src/Contracts/DataTableScope.php
+++ b/src/Contracts/DataTableScope.php
@@ -7,7 +7,7 @@ interface DataTableScope
     /**
      * Apply a query scope.
      *
-     * @param  \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Eloquent\Relations\Relation  $query
+     * @param  \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Eloquent\Relations\Relation|Illuminate\Support\Collection  $query
      * @return mixed
      */
     public function apply($query);

--- a/src/Contracts/DataTableScope.php
+++ b/src/Contracts/DataTableScope.php
@@ -7,7 +7,7 @@ interface DataTableScope
     /**
      * Apply a query scope.
      *
-     * @param  \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Eloquent\Relations\Relation|Illuminate\Support\Collection  $query
+     * @param  \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Eloquent\Relations\Relation|\Illuminate\Support\Collection  $query
      * @return mixed
      */
     public function apply($query);

--- a/src/Services/DataTable.php
+++ b/src/Services/DataTable.php
@@ -713,10 +713,10 @@ abstract class DataTable implements DataTableButtons
     /**
      * Apply query scopes.
      *
-     * @param  EloquentBuilder|QueryBuilder|EloquentRelation  $query
-     * @return EloquentBuilder|QueryBuilder|EloquentRelation
+     * @param  EloquentBuilder|QueryBuilder|EloquentRelation|Collection  $query
+     * @return EloquentBuilder|QueryBuilder|EloquentRelation|Collection
      */
-    protected function applyScopes(EloquentBuilder|QueryBuilder|EloquentRelation $query): EloquentBuilder|QueryBuilder|EloquentRelation
+    protected function applyScopes(EloquentBuilder|QueryBuilder|EloquentRelation|Collection $query): EloquentBuilder|QueryBuilder|EloquentRelation|Collection
     {
         foreach ($this->scopes as $scope) {
             $scope->apply($query);


### PR DESCRIPTION
This pull request fix the issue that when we create a DataTable service from php artisan datatables:make command, the service cannot support CollectionDatatable because applyScopes method in Yajra\DataTables\Services\DataTable class only support EloquentBuilder|QueryBuilder|EloquentRelation.
<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you read the [Contributing Guidelines](https://github.com/yajra/laravel-datatables-buttons/blob/master/.github/CONTRIBUTING.md)?

If you answered yes, thanks for the PR and we'll get to it ASAP! :)

-->
