### PR TITLE
fix: prevent redeclaring export query generator function (Laravel Octane)

### DIFF
--- a/src/Services/DataTable.php
+++ b/src/Services/DataTable.php
@@ -799,15 +799,12 @@ abstract class DataTable implements DataTableButtons
         $dataTable->skipPaging();
 
         if ($dataTable instanceof QueryDataTable) {
-            // @phpstan-ignore-next-line
-            $queryGenerator = function ($dataTable): Generator
-            {
+            $queryGenerator = function ($dataTable): Generator {
                 foreach ($dataTable->getFilteredQuery()->cursor() as $row) {
                     yield $row;
                 }
             };
 
-            // @phpstan-ignore-next-line
             return new FastExcel($queryGenerator($dataTable));
         }
 

--- a/src/Services/DataTable.php
+++ b/src/Services/DataTable.php
@@ -800,15 +800,15 @@ abstract class DataTable implements DataTableButtons
 
         if ($dataTable instanceof QueryDataTable) {
             // @phpstan-ignore-next-line
-            function queryGenerator($dataTable): Generator
+            $queryGenerator = function ($dataTable): Generator
             {
                 foreach ($dataTable->getFilteredQuery()->cursor() as $row) {
                     yield $row;
                 }
-            }
+            };
 
             // @phpstan-ignore-next-line
-            return new FastExcel(queryGenerator($dataTable));
+            return new FastExcel($queryGenerator($dataTable));
         }
 
         return new FastExcel($dataTable->toArray()['data']);


### PR DESCRIPTION
Currently, when using `FastExcel` exports within Laravel Octane, a fatal error is produced on consecutive export requests:

> PHP Fatal error:  Cannot redeclare Yajra\DataTables\Services\queryGenerator() (previously declared in /var/www/vendor/yajra/laravel-datatables-buttons/src/Services/DataTable.php:803) in /var/www/vendor/yajra/laravel-datatables-buttons/src/Services/DataTable.php on line 803

I think it should be completely safe and backwards compatible to use a variable for this scoped function instead of a named function.