### PR TITLE
fix: use callback function if exportRender method is set

### DIFF
--- a/src/Transformers/DataArrayTransformer.php
+++ b/src/Transformers/DataArrayTransformer.php
@@ -52,7 +52,12 @@ class DataArrayTransformer
                     $data = is_array($data) ? json_encode($data) : $this->decodeContent($data);
                 }
 
-                $results[$title] = $data;
+                if(isset($column->exportRender)){
+                    $callback = $column->exportRender;
+                    $results[$title] = $callback($row,$data);
+                }else{
+                    $results[$title] = $data;
+                }
             }
         });
 

--- a/src/Transformers/DataArrayTransformer.php
+++ b/src/Transformers/DataArrayTransformer.php
@@ -52,10 +52,10 @@ class DataArrayTransformer
                     $data = is_array($data) ? json_encode($data) : $this->decodeContent($data);
                 }
 
-                if(isset($column->exportRender)){
+                if (isset($column->exportRender)) {
                     $callback = $column->exportRender;
-                    $results[$title] = $callback($row,$data);
-                }else{
+                    $results[$title] = $callback($row, $data);
+                } else {
                     $results[$title] = $data;
                 }
             }


### PR DESCRIPTION
this commit is paired with another commit d48dc1bbe8bc860070240d6f1444e7a861c53789 which should be pushed together to make final result:

this commit is about development not bug fix:

i realize a need to render column data for export, i found it by adding Export Class to set how to render export
but i couldn't find any thing for render print
and i need a centralized render for print & export (for simplicity & integrity)
so i added exportRender method to be used for pass a callback function to determine how targeted column data should be rendered for print & export, sample code is shown below:
Column::make('used')->title('Use Status')->exportRender(function($row,$data){return $data == 1 ? 'Yes' : 'Not Yet'});

but in this commit we write just use of callback function for rendering column to print or export as we expected
but commit d48dc1bbe8bc860070240d6f1444e7a861c53789 in laravel-datatable-html repo should be pushed to exportRender method added to Column Builder for adding callback function


please accept that pull request before this pull request