### PR TITLE
fix: static analysis

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,6 +10,7 @@ parameters:
 
     ignoreErrors:
         - '#Unsafe usage of new static\(\).#'
+        - '#Command "datatables:html" does not have option*#'
 
     excludePaths:
 


### PR DESCRIPTION
Ignore `Command "datatables:html" does not have option*` error

<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you read the [Contributing Guidelines](https://github.com/yajra/laravel-datatables-buttons/blob/master/.github/CONTRIBUTING.md)?

If you answered yes, thanks for the PR and we'll get to it ASAP! :)

-->
