### PR TITLE
fix: Update composer.json to use Larastan org

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   },
   "require-dev": {
     "maatwebsite/excel": "^3.1.46",
-    "nunomaduro/larastan": "^2.4",
+    "larastan/larastan": "^2.4",
     "orchestra/testbench": "^8",
     "rap2hpoutre/fast-excel": "^5.1",
     "barryvdh/laravel-snappy": "^1.0.1"

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 includes:
-    - ./vendor/nunomaduro/larastan/extension.neon
+    - ./vendor/larastan/larastan/extension.neon
 
 parameters:
 


### PR DESCRIPTION
Starting with Larastan 2.7.0, the Larastan repository will now be managed under the Larastan organization. To ensure we receive the most recent updates, I've made the necessary updates to both the `composer.json` and `phpstan.neon.dist` files.