### PR TITLE
feat: fast excel export via Column's exportRender()

### DIFF
--- a/src/Services/DataTable.php
+++ b/src/Services/DataTable.php
@@ -678,7 +678,13 @@ abstract class DataTable implements DataTableButtons
             $this->exportColumns()
                 ->reject(fn (Column $column) => $column->exportable === false)
                 ->each(function (Column $column) use (&$mapped, $row) {
-                    $mapped[$column->title] = $row[$column->data];
+                    $callback = $column->exportRender ?? null;
+
+                    if (isset($callback) && is_callable($callback)) {
+                        $mapped[$column->title] = $callback($row, $row[$column->data]);
+                    } else {
+                        $mapped[$column->title] = $row[$column->data];
+                    }
                 });
 
             return $mapped;

--- a/src/Services/DataTable.php
+++ b/src/Services/DataTable.php
@@ -680,7 +680,7 @@ abstract class DataTable implements DataTableButtons
                 ->each(function (Column $column) use (&$mapped, $row) {
                     $callback = $column->exportRender ?? null;
 
-                    if (isset($callback) && is_callable($callback)) {
+                    if (is_callable($callback)) {
                         $mapped[$column->title] = $callback($row, $row[$column->data]);
                     } else {
                         $mapped[$column->title] = $row[$column->data];


### PR DESCRIPTION
Since this [pull request](https://github.com/yajra/laravel-datatables-buttons/pull/186), per cell styling is supported via exportFormat() of Column class.

This pull request takes it further by supporting the exportRender() of Column when using fast excel to provide another way to modify cell data.

### Usage

```php
class YourDataTable extends DataTable
{
    protected bool $fastExcel = true;
    
    public function html()
    {
        return $this->builder()
            ->columns([
                \Yajra\DataTables\Html\Column::make('created_at')->exportRender(function ($row, $data) {
                    return \Carbon\Carbon::parse($data)->format('m/d/Y h:i a');
                })
            ]);
    }
}
```