### PR TITLE
Fix: Avoid redundant call to buildExcelFile in csv method

### DIFF
--- a/src/Services/DataTable.php
+++ b/src/Services/DataTable.php
@@ -530,7 +530,7 @@ abstract class DataTable implements DataTableButtons
         }
 
         // @phpstan-ignore-next-line
-        return $this->buildExcelFile()->download($path, $this->csvWriter);
+        return $excelFile->download($path, $this->csvWriter);
     }
 
     /**


### PR DESCRIPTION
### What Does This PR Do?
- Fixes a redundancy in the `csv()` method where `buildExcelFile()` was called twice.

### Why Is This Needed?
- Calling `buildExcelFile()` multiple times introduces unnecessary processing, especially for large datasets.

Fixes #192