### PR TITLE
feat: Macroable DataTable Base Class

### DIFF
--- a/src/Services/DataTable.php
+++ b/src/Services/DataTable.php
@@ -15,6 +15,7 @@ use Illuminate\Http\Response;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\LazyCollection;
+use Illuminate\Support\Traits\Macroable;
 use Maatwebsite\Excel\ExcelServiceProvider;
 use OpenSpout\Common\Entity\Style\Style;
 use Rap2hpoutre\FastExcel\FastExcel;
@@ -29,6 +30,8 @@ use Yajra\DataTables\Utilities\Request;
 
 abstract class DataTable implements DataTableButtons
 {
+    use Macroable;
+
     /**
      * DataTables print preview view.
      *

--- a/tests/DataTableServiceTest.php
+++ b/tests/DataTableServiceTest.php
@@ -10,6 +10,7 @@ use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Yajra\DataTables\Buttons\Tests\DataTables\UsersDataTable;
 use Yajra\DataTables\Buttons\Tests\Models\User;
 use Yajra\DataTables\EloquentDataTable;
+use Yajra\DataTables\Services\DataTable;
 
 class DataTableServiceTest extends TestCase
 {
@@ -78,6 +79,20 @@ class DataTableServiceTest extends TestCase
 
         $this->assertEquals(2, $response->json('recordsTotal'));
         $this->assertEquals(1, $response->json('recordsFiltered'));
+    }
+
+    #[Test]
+    public function it_is_macroable(): void
+    {
+        $dataTable = new class extends DataTable {};
+
+        $this->assertObjectHasProperty('macros', $dataTable);
+        $this->assertTrue(method_exists($dataTable, 'macro'), 'Method macro does not exist.');
+        $this->assertTrue(method_exists($dataTable, 'mixin'), 'Method mixin does not exist.');
+
+        DataTable::macro('macroMethod', fn () => 'macro');
+
+        $this->assertEquals('macro', $dataTable->macroMethod());
     }
 
     protected function setUp(): void


### PR DESCRIPTION
This PR aims to give Yajra\DataTables\Services\DataTable base class more flexibility by adding the Illuminate\Support\Traits\Macroable trait which allows us to register custom methods.

```php
class AppServiceProvider extends ServiceProvider
{
    public function boot(): void
    {
        Yajra\DataTables\Services\DataTable::macro('foo', fn (): string => 'bar');
    }
}

$dataTable = new class extends Yajra\DataTables\Services\DataTable {}
$dataTable->foo(); // returns 'bar'
```