### PR TITLE
feat: DataTable as route action

### DIFF
--- a/src/Services/DataTable.php
+++ b/src/Services/DataTable.php
@@ -151,6 +151,11 @@ abstract class DataTable implements DataTableButtons
      */
     protected string $pdfWriter = 'Dompdf';
 
+    /**
+     * @phpstan-var view-string|null
+     */
+    protected ?string $view = null;
+
     public function __construct()
     {
         /** @var Request $request */
@@ -161,6 +166,11 @@ abstract class DataTable implements DataTableButtons
 
         $this->request = $request;
         $this->htmlBuilder = $builder;
+    }
+
+    public function __invoke(): mixed
+    {
+        return $this->render($this->view, $this->viewData(), $this->viewMergeData());
     }
 
     /**
@@ -741,5 +751,21 @@ abstract class DataTable implements DataTableButtons
         }
 
         return (new FastExcel($dataTable->toArray()['data']))->setColumnStyles($styles);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function viewData(): array
+    {
+        return [];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function viewMergeData(): array
+    {
+        return [];
     }
 }

--- a/tests/DataTableServiceTest.php
+++ b/tests/DataTableServiceTest.php
@@ -4,6 +4,7 @@ namespace Yajra\DataTables\Buttons\Tests;
 
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Http\Response;
+use Illuminate\Routing\Router;
 use Illuminate\Support\Collection;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
@@ -93,6 +94,23 @@ class DataTableServiceTest extends TestCase
         DataTable::macro('macroMethod', fn () => 'macro');
 
         $this->assertEquals('macro', $dataTable->macroMethod());
+    }
+
+    #[Test]
+    public function it_can_be_used_as_route_action(): void
+    {
+        /** @var Router|null $router */
+        $router = $this->app['router'] ?? null;
+        $router?->get('datatables-as-route-action', UsersDataTable::class);
+
+        $this->get('datatables-as-route-action')
+            ->assertSeeText('LaravelDataTables')
+            ->assertSeeText('This is a test description');
+
+        // Assert that view data are not present when manually calling render
+        $this->get('users')
+            ->assertSeeText('DataTable')
+            ->assertSeeText('No description');
     }
 
     protected function setUp(): void

--- a/tests/DataTables/UsersDataTable.php
+++ b/tests/DataTables/UsersDataTable.php
@@ -10,6 +10,8 @@ use Yajra\DataTables\Services\DataTable;
 
 class UsersDataTable extends DataTable
 {
+    protected ?string $view = 'tests::users';
+
     public function dataTable(Builder $query): EloquentDataTable
     {
         return (new EloquentDataTable($query))
@@ -35,5 +37,13 @@ class UsersDataTable extends DataTable
     protected function filename(): string
     {
         return 'Users';
+    }
+
+    protected function viewData(): array
+    {
+        return [
+            'title' => 'LaravelDataTables',
+            'description' => 'This is a test description',
+        ];
     }
 }

--- a/tests/views/users.blade.php
+++ b/tests/views/users.blade.php
@@ -1,3 +1,7 @@
-{{ $dataTable->table() }}
+<h2>{{ $title ?? 'DataTable' }}</h2>
+<p>{{ $description ?? 'No description' }}</p>
+<div>
+    {{ $dataTable->table() }}
+</div>
 
 {{ $dataTable->scripts() }}


### PR DESCRIPTION
This PR allows DataTables extending Yajra\DataTables\Services\DataTable to be passed as route action when defining routes:

```php
// web.php
Route::get('/roles', RolesDataTable::class);

// RolesDataTable
class RolesDataTable extends Yajra\DataTables\Services\DataTable
{
    protected ?string $view = 'roles.index';

    public function dataTable(...) {...}

    public function query(...) {...}

    #[\Override]
    protected function viewData(): array
    {
        return [
            'title' => 'Manage Roles',
            'breadcrumbs' => [
                'Administration',
                'ACL',
                'Roles',
            ],
            'widgets' => view('roles.widgets'),
            'rolesCount' => $this->query()->count(),
        ];
    }
}

// roles/index.blade.php
<x-layouts.admin>
    <x-slot:title>{{ $title }}</x-slot>

    <x-breadcrumbs>
        @foreach($breadcrumbs as $breadcrumb)
            <x-breadcrumbs.item>{{ $breadcrumb }}</x-breadcrumbs.item>
        @endforeach
    </x-breadcrumbs>

    {{ $widgets }}

    <x-stat-card :value="$rolesCount" description="Roles Count" />

    <x-datatable-wrapper :data-table="$dataTable" />
</x-layouts.admin>
```