### PR TITLE
fix(html): resolve make arguments through container

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ This package is a plugin of [Laravel DataTables](https://github.com/yajra/larave
 
 And that's it! Start building out some awesome DataTables!
 
+## HTML Builder Resolution
+
+`DataTableHtml::make()` resolves the HTML builder through Laravel's service container, whether or not constructor arguments are provided. Explicit positional arguments are passed to the resolved class as constructor overrides.
+
+Because container resolution happens before `handle()` builds the table, applications can use container bindings and `resolving` or `afterResolving` callbacks to configure or extend the HTML builder consistently.
+
 ## Contributing
 
 Please see [CONTRIBUTING](https://github.com/yajra/laravel-datatables-buttons/blob/master/.github/CONTRIBUTING.md) for details.

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,7 +9,6 @@ parameters:
     level: max
 
     ignoreErrors:
-        - '#Unsafe usage of new static\(\).#'
         -   identifier: missingType.generics
         -   identifier: missingType.iterableValue
         -   identifier: argument.type

--- a/src/Html/DataTableHtml.php
+++ b/src/Html/DataTableHtml.php
@@ -2,9 +2,11 @@
 
 namespace Yajra\DataTables\Html;
 
+use Closure;
 use Illuminate\Support\Facades\Request;
 use Illuminate\Support\Traits\ForwardsCalls;
 use ReflectionClass;
+use ReflectionFunction;
 use Yajra\DataTables\Contracts\DataTableHtmlBuilder;
 use Yajra\DataTables\Html\Editor\Editor;
 
@@ -18,15 +20,47 @@ abstract class DataTableHtml implements DataTableHtmlBuilder
 
     public static function make(): Builder
     {
+        $arguments = func_get_args();
+
         /** @var static $html */
-        $html = app(static::class, self::normalizeParameters(func_get_args()));
+        $html = self::hasVariadicConstructor()
+            ? self::resolveVariadic($arguments)
+            : app(static::class, self::normalizeParameters($arguments));
 
         return $html->handle();
     }
 
+    private static function hasVariadicConstructor(): bool
+    {
+        foreach (self::constructorParameters() as $parameter) {
+            if ($parameter->isVariadic()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static function resolveVariadic(array $arguments): static
+    {
+        $container = app();
+        $reflection = new ReflectionClass(self::concreteClass());
+        $resolver = fn (): object => $reflection->newInstanceArgs($arguments);
+        $abstract = static::class.'@'.spl_object_hash($resolver);
+
+        $container->bind($abstract, $resolver);
+
+        try {
+            /** @var static */
+            return $container->make($abstract);
+        } finally {
+            unset($container[$abstract]);
+        }
+    }
+
     private static function normalizeParameters(array $arguments): array
     {
-        $constructorParameters = (new ReflectionClass(static::class))->getConstructor()?->getParameters() ?? [];
+        $constructorParameters = self::constructorParameters();
         $parameters = [];
 
         foreach ($arguments as $index => $argument) {
@@ -38,6 +72,23 @@ abstract class DataTableHtml implements DataTableHtmlBuilder
         }
 
         return $parameters;
+    }
+
+    private static function constructorParameters(): array
+    {
+        return (new ReflectionClass(self::concreteClass()))->getConstructor()?->getParameters() ?? [];
+    }
+
+    private static function concreteClass(): string
+    {
+        $binding = app()->getBindings()[static::class]['concrete'] ?? null;
+        $concrete = $binding instanceof Closure
+            ? (new ReflectionFunction($binding))->getStaticVariables()['concrete'] ?? static::class
+            : static::class;
+
+        return is_string($concrete) && is_a($concrete, static::class, true)
+            ? $concrete
+            : static::class;
     }
 
     /**

--- a/src/Html/DataTableHtml.php
+++ b/src/Html/DataTableHtml.php
@@ -4,6 +4,7 @@ namespace Yajra\DataTables\Html;
 
 use Illuminate\Support\Facades\Request;
 use Illuminate\Support\Traits\ForwardsCalls;
+use ReflectionClass;
 use Yajra\DataTables\Contracts\DataTableHtmlBuilder;
 use Yajra\DataTables\Html\Editor\Editor;
 
@@ -17,14 +18,26 @@ abstract class DataTableHtml implements DataTableHtmlBuilder
 
     public static function make(): Builder
     {
-        if (func_get_args()) {
-            return (new static(...func_get_args()))->handle();
-        }
-
         /** @var static $html */
-        $html = app(static::class);
+        $html = app(static::class, self::normalizeParameters(func_get_args()));
 
         return $html->handle();
+    }
+
+    private static function normalizeParameters(array $arguments): array
+    {
+        $constructorParameters = (new ReflectionClass(static::class))->getConstructor()?->getParameters() ?? [];
+        $parameters = [];
+
+        foreach ($arguments as $index => $argument) {
+            if (! isset($constructorParameters[$index])) {
+                break;
+            }
+
+            $parameters[$constructorParameters[$index]->getName()] = $argument;
+        }
+
+        return $parameters;
     }
 
     /**

--- a/tests/DataTableHtmlTest.php
+++ b/tests/DataTableHtmlTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Yajra\DataTables\Buttons\Tests;
+
+use PHPUnit\Framework\Attributes\Test;
+use Yajra\DataTables\Html\DataTableHtml;
+
+class DataTableHtmlTest extends TestCase
+{
+    #[Test]
+    public function it_resolves_the_static_class_with_positional_arguments_through_the_container(): void
+    {
+        $repository = app(DataTableHtmlUserRepository::class);
+        $repository->tablePrefix = 'explicit-';
+
+        $builder = ContainerResolvedDataTableHtml::make($repository, 'users');
+
+        $this->assertSame('explicit-users', $builder->getTableId());
+    }
+}
+
+class ContainerResolvedDataTableHtml extends DataTableHtml
+{
+    public function __construct(DataTableHtmlUserRepository $repository, string $tableId)
+    {
+        $this->tableId = $repository->tablePrefix.$tableId;
+    }
+}
+
+class DataTableHtmlUserRepository
+{
+    public string $tablePrefix = 'container-';
+}

--- a/tests/DataTableHtmlTest.php
+++ b/tests/DataTableHtmlTest.php
@@ -8,6 +8,14 @@ use Yajra\DataTables\Html\DataTableHtml;
 class DataTableHtmlTest extends TestCase
 {
     #[Test]
+    public function it_resolves_constructor_dependencies_through_the_container_without_explicit_arguments(): void
+    {
+        $builder = ContainerResolvedDataTableHtml::make();
+
+        $this->assertSame('container-users', $builder->getTableId());
+    }
+
+    #[Test]
     public function it_resolves_the_static_class_with_positional_arguments_through_the_container(): void
     {
         $repository = app(DataTableHtmlUserRepository::class);
@@ -21,7 +29,7 @@ class DataTableHtmlTest extends TestCase
 
 class ContainerResolvedDataTableHtml extends DataTableHtml
 {
-    public function __construct(DataTableHtmlUserRepository $repository, string $tableId)
+    public function __construct(DataTableHtmlUserRepository $repository, string $tableId = 'users')
     {
         $this->tableId = $repository->tablePrefix.$tableId;
     }

--- a/tests/DataTableHtmlTest.php
+++ b/tests/DataTableHtmlTest.php
@@ -25,6 +25,47 @@ class DataTableHtmlTest extends TestCase
 
         $this->assertSame('explicit-users', $builder->getTableId());
     }
+
+    #[Test]
+    public function it_passes_all_positional_arguments_to_a_variadic_constructor(): void
+    {
+        $builder = VariadicDataTableHtml::make('users', 'active');
+
+        $this->assertSame('users-active', $builder->getTableId());
+    }
+
+    #[Test]
+    public function it_maps_positional_arguments_to_the_bound_concrete_constructor(): void
+    {
+        app()->bind(ContainerResolvedDataTableHtml::class, BoundDataTableHtml::class);
+
+        $repository = app(DataTableHtmlUserRepository::class);
+        $repository->tablePrefix = 'explicit-';
+
+        $builder = ContainerResolvedDataTableHtml::make($repository, 'users');
+
+        $this->assertSame('bound-explicit-users', $builder->getTableId());
+    }
+
+    #[Test]
+    public function it_runs_container_lifecycle_callbacks_before_handling(): void
+    {
+        app()->resolving(
+            ContainerResolvedDataTableHtml::class,
+            fn (ContainerResolvedDataTableHtml $html) => $html->prefixTableId('resolving-')
+        );
+        app()->afterResolving(
+            ContainerResolvedDataTableHtml::class,
+            fn (ContainerResolvedDataTableHtml $html) => $html->prefixTableId('resolved-')
+        );
+
+        $repository = app(DataTableHtmlUserRepository::class);
+        $repository->tablePrefix = 'explicit-';
+
+        $builder = ContainerResolvedDataTableHtml::make($repository, 'users');
+
+        $this->assertSame('resolved-resolving-explicit-users', $builder->getTableId());
+    }
 }
 
 class ContainerResolvedDataTableHtml extends DataTableHtml
@@ -33,9 +74,30 @@ class ContainerResolvedDataTableHtml extends DataTableHtml
     {
         $this->tableId = $repository->tablePrefix.$tableId;
     }
+
+    public function prefixTableId(string $prefix): void
+    {
+        $this->tableId = $prefix.$this->tableId;
+    }
 }
 
 class DataTableHtmlUserRepository
 {
     public string $tablePrefix = 'container-';
+}
+
+class VariadicDataTableHtml extends DataTableHtml
+{
+    public function __construct(string ...$tableIdParts)
+    {
+        $this->tableId = implode('-', $tableIdParts);
+    }
+}
+
+class BoundDataTableHtml extends ContainerResolvedDataTableHtml
+{
+    public function __construct(DataTableHtmlUserRepository $dataSource, string $identifier = 'users')
+    {
+        $this->tableId = 'bound-'.$dataSource->tablePrefix.$identifier;
+    }
 }


### PR DESCRIPTION
## Summary

Ensure `DataTableHtml::make()` always resolves the HTML builder through Laravel's service container, including when constructor arguments are provided.

## Why

Previously, `make()` used two different construction paths:

- Without arguments, the class was resolved through the container.
- With arguments, it was instantiated directly using `new static(...)`.

Direct construction bypassed container bindings and Laravel's resolving lifecycle. This meant applications and packages could not use `resolving` or `afterResolving` callbacks to configure, extend, or observe a `DataTableHtml` instance when constructor arguments were supplied.

Resolving every instance through the container provides consistent behavior and ensures lifecycle callbacks run before `handle()` builds the table. It also removes the need to suppress PHPStan's unsafe `new static()` warning.

## How

- Convert positional arguments into named constructor parameters expected by the container.
- Resolve the class through `app()` for both zero-argument and explicit-argument calls.
- Allow container `resolving` and `afterResolving` callbacks to run consistently before `handle()`.
- Remove the obsolete PHPStan suppression for unsafe `new static()`.
- Add coverage for:
  - Container-resolved dependencies when `make()` receives no arguments.
  - Explicit positional constructor arguments passed through the container.
  - Variadic constructor arguments.
  - Container-bound implementations with different constructor parameter names.
  - `resolving` and `afterResolving` callbacks running before `handle()`.
- Document the HTML builder's container-resolution behavior.

## Testing

- [x] PHPUnit — 20 tests, 52 assertions
- [x] PHPStan
- [x] Laravel Pint
- [x] Rector dry-run
